### PR TITLE
Switch TravisCI to Ubuntu Trusty

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: trusty
 language: node_js
 node_js:
   - "4"


### PR DESCRIPTION
See https://blog.travis-ci.com/2017-07-11-trusty-as-default-linux-is-coming