### PR TITLE
Reliable/ordered mode and performance improvements

### DIFF
--- a/LICENSE-MIT
+++ b/LICENSE-MIT
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2016-2018 Threema GmbH / SaltyRTC Contributors
+Copyright (c) 2016-2019 Threema GmbH / SaltyRTC Contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ You can also install a pre-push hook to do the linting:
 
 ## License
 
-    Copyright (c) 2016-2018 Threema GmbH
+    Copyright (c) 2016-2019 Threema GmbH
     
     Licensed under the Apache License, Version 2.0, <see LICENSE-APACHE file>
     or the MIT license <see LICENSE-MIT file>, at your option. This file may not be

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ const unchunker = new ReliableOrderedUnchunker(buffer);
 ```
 
 The `buffer` is optional. If supplied, it will be continuously used for
-reassembling messages. If the message grows larger than `buffer`, it will be
+reassembling messages. If the message grows larger than `buffer`, the buffer will be
 replaced. Supplying a `buffer` allows for slightly improved performance.
 Regardless of whether or not it is being used, each message retrieved needs to
 be processed or copied immediately before a next chunk can be added to the

--- a/README.md
+++ b/README.md
@@ -50,16 +50,16 @@ in the main directory.
 For each message that you want to split into chunks, pass it to a `Chunker`.
 
 ```javascript
-let messageId = 1337;
-let message = Uint8Array.of(1, 2, 3, 4, 5, 6, 7, 8);
-let chunkSize = 12; // Chunk size *including* 9 byte header
-let chunker = new Chunker(messageId, message, chunkSize);
+const messageId = 1337;
+const message = Uint8Array.of(1, 2, 3, 4, 5, 6, 7, 8);
+const chunkSize = 12; // Chunk size *including* 9 byte header
+const chunker = new Chunker(messageId, message, chunkSize);
 ```
 
 You can then process all chunks using the iterator/iterable protocol:
 
 ```javascript
-for (let chunk of chunker) {
+for (const chunk of chunker) {
     // Send chunk to peer
 }
 ```
@@ -68,7 +68,7 @@ Alternatively you can also use the `next()` method directly:
 
 ```javascript
 while (chunker.hasNext) {
-    let chunk = chunker.next().value;
+    const chunk = chunker.next().value;
     // Send chunk to peer
 }
 ```
@@ -93,7 +93,7 @@ let unchunker = new Unchunker();
 Register a message listener:
 
 ```javascript
-unchunker.onMessage = (message: Uint8Array, context: any[]) => {
+unchunker.onMessage = (message: Uint8Array) => {
     // Do something with the received message
 };
 ```

--- a/README.md
+++ b/README.md
@@ -107,11 +107,11 @@ const unchunker = new ReliableOrderedUnchunker(buffer);
 ```
 
 The `buffer` is optional. If supplied, it will be continuously used for
-reassembling messages. If the message grows larger than `buffer`, the buffer will be
-replaced. Supplying a `buffer` allows for slightly improved performance.
-Regardless of whether or not it is being used, each message retrieved needs to
-be processed or copied immediately before a next chunk can be added to the
-unchunker.
+reassembling messages. If the message grows larger than `buffer`, the buffer
+will be replaced. Supplying a `buffer` allows for slightly improved
+performance. Regardless of whether or not it is being used, each message
+retrieved needs to be processed or copied immediately before a next chunk can
+be added to the unchunker.
 
 Register a message listener:
 
@@ -127,6 +127,9 @@ Finally, when new chunks arrive, add them to the unchunker instance:
 let chunk = ...; // Uint8Array
 unchunker.add(chunk);
 ```
+
+Note that this unchunker will reject chunks with modes other than
+reliable/ordered. 
 
 ### Unreliable/Unordered
 
@@ -165,6 +168,9 @@ let unchunker = new UnreliableUnorderedUnchunker();
 
 Registering a message listener and adding chunks is identical to the
 [reliable/ordered](#reliableordered) mode.
+
+Note that this unchunker will reject chunks with modes other than
+unreliable/unordered.
 
 #### Cleanup
 

--- a/README.md
+++ b/README.md
@@ -9,20 +9,26 @@
 This library allows you to split up large binary messages into multiple
 chunks of a certain size.
 
-When converting data to chunks, a 9 byte header is prepended to each
-chunk. This allows you to send the chunks to the receiver in any order.
+It allows you to choose between the following two modes:
+
+* **Reliable/Ordered**: Intended for reliable and ordered transmission
+  of chunks. Chunks may not be reordered and chunks of different
+  messages may not be interleaved.
+* **Unreliable/Unordered**: Intended for transmission of chunks where
+  chunks may be lost or reordered. **Important**: Duplication of chunks
+  is not allowed by this implementation.
 
 While the library was originally written for use with WebRTC
 DataChannels, it can also be used outside of that scope.
 
-The full specification for the chunking format can be found
+The full specification for the chunking wire format can be found
 [here](https://github.com/saltyrtc/saltyrtc-meta/blob/master/Chunking.md).
 
 
 ## Installing
 
-If you're writing a browser application, simply use the normal or
-minified ES5 distribution from the `dist` directory.
+If you're writing a browser application, use the normal or minified ES5
+distribution from the `dist` directory.
 
     <script src="chunked-dc.es5.min.polyfill.js"></script>
 
@@ -30,33 +36,45 @@ If you have a build pipeline yourself, you may also want to use the ES2015
 version instead. The ES5 polyfill version is considerably larger because it
 also contains ES5 polyfills.
 
-Alternatively, simply install the library via `npm`:
+Alternatively, install the library via `npm`:
 
     npm install --save @saltyrtc/chunked-dc
 
 All classes in the ES5 version are namespaced under `chunkedDc`:
 
-- `chunkedDc.Chunker`
-- `chunkedDc.Unchunker`
+- `chunkedDc.ReliableOrderedChunker`
+- `chunkedDc.ReliableOrderedUnchunker`
+- `chunkedDc.UnreliableUnorderedChunker`
+- `chunkedDc.UnreliableUnorderedUnchunker`
+- ...
 
-To build the distributions yourself, simply run `npm install && npm run dist`
-in the main directory.
+To build the distributions yourself, run `npm install && npm run dist` in the
+main directory.
 
 
 ## Usage
 
-### Chunking
+### Reliable/Ordered
 
-For each message that you want to split into chunks, pass it to a `Chunker`.
+#### Chunking
+
+For each message that you want to split into chunks, pass it to a
+`ReliableOrderedChunker`.
 
 ```javascript
 const messageId = 1337;
 const message = Uint8Array.of(1, 2, 3, 4, 5, 6, 7, 8);
-const chunkSize = 12; // Chunk size *including* 9 byte header
-const chunker = new Chunker(messageId, message, chunkSize);
+const chunkLength = 4; // Chunk byte length *including* 1 byte header
+const buffer = new ArrayBuffer(chunkSize);
+const chunker = new ReliableOrderedChunker(message, chunkLength, buffer);
 ```
 
-You can then process all chunks using the iterator/iterable protocol:
+The `buffer` is optional. If supplied, the chunker can continuously reuse the
+buffer as temporary chunk storage. While this increases performance, each chunk
+retrieved from the chunker needs to be processed or copied before a next chunk
+can be safely retrieved.
+
+You can then retrieve chunks using the iterator/iterable protocol:
 
 ```javascript
 for (const chunk of chunker) {
@@ -69,26 +87,31 @@ Alternatively you can also use the `next()` method directly:
 ```javascript
 while (chunker.hasNext) {
     const chunk = chunker.next().value;
-    // Send chunk to peer
+    // Transmit chunk to peer who is unchunking
 }
 ```
 
 The example above will return 3 chunks (header prefix not shown):
 `[1, 2, 3], [4, 5, 6], [7, 8]`.
 
-### Unchunking
+#### Unchunking
 
-This library works both if chunks are sent in ordered or unordered
-manner. Because ordering is not guaranteed, the Unchunker instance
-accepts chunks and stores them in an internal data structure. As soon as
-all chunks of a message have arrived, a listener will be notified.
-Repeated chunks with the same serial will be ignored.
+The `ReliableOrderedUnchunker` adds ordered chunks into a contiguous buffer. As
+soon as all chunks of a message have been added, a listener will be notified.
 
-Create the Unchunker instance:
+Create the `ReliableOrderedUnchunker` instance:
 
 ```javascript
-let unchunker = new Unchunker();
+const buffer = new ArrayBuffer(128);
+const unchunker = new ReliableOrderedUnchunker(buffer);
 ```
+
+The `buffer` is optional. If supplied, it will be continuously used for
+reassembling messages. If the message grows larger than `buffer`, it will be
+replaced. Supplying a `buffer` allows for slightly improved performance.
+Regardless of whether or not it is being used, each message retrieved needs to
+be processed or copied immediately before a next chunk can be added to the
+unchunker.
 
 Register a message listener:
 
@@ -98,39 +121,71 @@ unchunker.onMessage = (message: Uint8Array) => {
 };
 ```
 
-Finally, when new chunks arrive, simply add them to the `Unchunker` instance:
+Finally, when new chunks arrive, add them to the unchunker instance:
 
 ```
-let chunk = ...; // ArrayBuffer
+let chunk = ...; // Uint8Array
 unchunker.add(chunk);
 ```
 
-You may also pass some context object to the unchunker which will be
-stored together with the chunk. When the `onMessage` handler is
-notified, these context objects will be passed in as a list ordered by
-chunk serial.
+### Unreliable/Unordered
 
-### Cleanup
+The unreliable/unordered mode usage is very similar to the
+[reliable/ordered](#reliableordered) mode. We will only mention differences
+regarding usage.
 
-Because the `Unchunker` instance needs to keep track of arrived chunks,
-it's possible that incomplete messages add up and use a lot of memory
-without ever being freed.
+#### Chunking
 
-To avoid this, simply call the `Unchunker.gc(maxAge: number)` method
-regularly. It will remove all incomplete messages that haven't been
+You can create an `UnreliableUnorderedChunker` in the following way:
+
+```javascript
+const messageId = 1337;
+const message = Uint8Array.of(1, 2, 3, 4, 5, 6, 7, 8);
+const chunkLength = 12; // Chunk byte length *including* 9 byte header
+const buffer = new ArrayBuffer(chunkSize);
+const chunker = new UnreliableUnorderedChunker(
+    messageId, message, chunkLength, buffer);
+```
+
+Retrieving chunks is identical to the [reliable/ordered](#reliableordered)
+mode.
+
+#### Unchunking
+
+This mode works both if chunks are sent in ordered or unordered manner. Because
+ordering is not guaranteed, the unchunker accepts chunks and stores them in an
+internal data structure. As soon as all chunks of a message have arrived, a
+listener will be notified.
+
+Create the `UnreliableUnorderedUnchunker` instance:
+
+```javascript
+let unchunker = new UnreliableUnorderedUnchunker();
+```
+
+Registering a message listener and adding chunks is identical to the
+[reliable/ordered](#reliableordered) mode.
+
+#### Cleanup
+
+Because the `UnreliableUnorderedUnchunker` instance needs to keep track of
+arrived chunks, it is possible that incomplete messages add up and use a lot of
+memory without ever being freed.
+
+To avoid this, call the `UnreliableUnorderedUnchunker.gc(maxAge: number)`
+method regularly. It will remove all incomplete messages that haven't been
 updated for more than `maxAge` milliseconds.
 
 ### Constants
 
 This library exposes the following constants:
 
-- `HEADER_LENGTH`: The number of bytes in the chunk header
-
-
-## Format
-
-The chunking format is described
-[in the specification](https://github.com/saltyrtc/saltyrtc-meta/blob/master/Chunking.md).
+- `RELIABLE_ORDERED_HEADER_LENGTH`: The number of bytes in the chunk header for
+  reliable/ordered mode.
+- `UNRELIABLE_UNORDERED_HEADER_LENGTH`: The number of bytes in the chunk header
+  for unreliable/unordered mode.
+- `Mode` contains a mapping to each mode which can be applied on the *options's
+  bit field* as defined by the chunking wire format.
 
 
 ## Type Declarations

--- a/chunked-dc.d.ts
+++ b/chunked-dc.d.ts
@@ -39,7 +39,7 @@ declare namespace chunkedDc {
     interface ReliableOrderedUnchunker extends Unchunker {}
 
     interface ReliableOrderedUnchunkerStatic {
-        new(): ReliableOrderedChunker;
+        new(buffer?: ArrayBuffer): ReliableOrderedChunker;
     }
 
     interface UnreliableUnorderedUnchunker extends Unchunker {

--- a/chunked-dc.d.ts
+++ b/chunked-dc.d.ts
@@ -1,10 +1,10 @@
 // Interfaces
 declare namespace chunkedDc {
-
     /** common.ts **/
 
-    interface CommonStatic {
-        HEADER_LENGTH: number;
+    interface Mode {
+        ReliableOrdered: number;
+        UnreliableUnordered: number;
     }
 
     /** chunker.ts **/
@@ -15,8 +15,16 @@ declare namespace chunkedDc {
         [Symbol.iterator](): IterableIterator<Uint8Array>;
     }
 
-    interface ChunkerStatic {
-        new(id: number, message: Uint8Array, chunkSize: number): Chunker
+    interface ReliableOrderedChunker extends Chunker {}
+
+    interface ReliableOrderedChunkerStatic {
+        new(message: Uint8Array, chunkLength: number, buffer?: ArrayBuffer): ReliableOrderedChunker;
+    }
+
+    interface UnreliableUnorderedChunker extends Chunker {}
+
+    interface UnreliableUnorderedChunkerStatic {
+        new(id: number, message: Uint8Array, chunkLength: number, buffer?: ArrayBuffer): UnreliableUnorderedChunker;
     }
 
     /** unchunker.ts **/
@@ -25,22 +33,34 @@ declare namespace chunkedDc {
 
     interface Unchunker {
         onMessage: MessageListener;
-        add(chunk: ArrayBuffer, context?: any): void;
+        add(chunk: Uint8Array): void;
+    }
+
+    interface ReliableOrderedUnchunker extends Unchunker {}
+
+    interface ReliableOrderedUnchunkerStatic {
+        new(): ReliableOrderedChunker;
+    }
+
+    interface UnreliableUnorderedUnchunker extends Unchunker {
         gc(maxAge: number): number;
     }
 
-    interface UnchunkerStatic {
-        new(): Unchunker;
+    interface UnreliableUnorderedUnchunkerStatic {
+        new(): UnreliableUnorderedUnchunker;
     }
 
     /** main.ts **/
 
     interface Standalone {
-        Chunker: ChunkerStatic;
-        Unchunker: UnchunkerStatic;
-        HEADER_LENGTH: number;
+        Mode: Mode,
+        RELIABLE_ORDERED_HEADER_LENGTH: number;
+        UNRELIABLE_UNORDERED_HEADER_LENGTH: number;
+        ReliableOrderedChunker: ReliableOrderedChunkerStatic;
+        UnreliableUnorderedChunker: UnreliableUnorderedChunkerStatic;
+        ReliableOrderedUnchunker: ReliableOrderedUnchunkerStatic;
+        UnreliableUnorderedUnchunker: UnreliableUnorderedUnchunkerStatic;
     }
-
 }
 
 // Entry point

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -4,9 +4,8 @@ module.exports = function(config) {
         files: [
             'chunked-dc.js',
             'tests/tests.js',
-            'tests/performance.js',
         ],
         browsers: ['Firefox'],
-        browserDisconnectTimeout: 10000,
+        browserDisconnectTimeout: 3000,
     });
 };

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -7,4 +7,4 @@ module.exports = function(config) {
         ],
         browsers: ['Firefox']
     });
-}
+};

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -3,8 +3,10 @@ module.exports = function(config) {
         frameworks: ['jasmine'],
         files: [
             'chunked-dc.js',
-            'tests/tests.js'
+            'tests/tests.js',
+            'tests/performance.js',
         ],
-        browsers: ['Firefox']
+        browsers: ['Firefox'],
+        browserDisconnectTimeout: 10000,
     });
 };

--- a/rollup/es2015.js
+++ b/rollup/es2015.js
@@ -19,7 +19,7 @@ export default {
                 " * " + p.description + "\n" +
                 " * " + p.homepage + "\n" +
                 " *\n" +
-                " * Copyright (C) 2016-2018 " + p.author + "\n" +
+                " * Copyright (C) 2016-2019 " + p.author + "\n" +
                 " *\n" +
                 " * Licensed under the Apache License, Version 2.0, <see LICENSE-APACHE file>\n" +
                 " * or the MIT license <see LICENSE-MIT file>, at your option. This file may not be\n" +

--- a/rollup/es5.js
+++ b/rollup/es5.js
@@ -18,6 +18,6 @@ config.plugins.push(
             }]
         ],
     })
-)
+);
 
 export default config;

--- a/src/chunker.ts
+++ b/src/chunker.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2018 Threema GmbH / SaltyRTC Contributors
+ * Copyright (C) 2016-2019 Threema GmbH / SaltyRTC Contributors
  *
  * Licensed under the Apache License, Version 2.0, <see LICENSE-APACHE file>
  * or the MIT license <see LICENSE-MIT file>, at your option. This file may not be

--- a/src/chunker.ts
+++ b/src/chunker.ts
@@ -7,54 +7,64 @@
  */
 /// <reference path='../chunked-dc.d.ts' />
 
-import { Common } from './common';
+import { Mode, RELIABLE_ORDERED_HEADER_LENGTH, UNRELIABLE_UNORDERED_HEADER_LENGTH } from './common';
 
 /**
- * A Chunker instance splits up an Uint8Array into multiple chunks.
+ * A chunker fragments a single message into multiple chunks.
  *
- * The Chunker is initialized with an ID. For each message to be chunked,
- * a new Chunker instance is required.
+ * For each message to be chunked, a new instance is required.
  */
-export class Chunker implements chunkedDc.Chunker {
-
-    private id: number;
-    private chunkDataSize: number;
-    private chunkId: number = 0;
-    private message: Uint8Array;
+abstract class AbstractChunker implements chunkedDc.Chunker {
+    private readonly mode: Mode;
+    private readonly id: number | null;
+    private readonly message: Uint8Array;
+    private readonly headerLength: number;
+    private readonly payloadLength: number;
+    private readonly buffer: ArrayBuffer | null;
+    private offset: number = 0;
+    private serial: number = 0;
 
     /**
-     * Create a Chunker instance.
-     *
-     * @param id An identifier for the message. Must be between 0 and 2**32-1.
-     * @param message The Uint8Array containing the bytes that should be chunked.
-     * @param chunkSize The chunk size *including* header data.
+     * Create a chunker for a specific mode.
      */
-    constructor(id: number, message: Uint8Array, chunkSize: number) {
-        if (chunkSize < (Common.HEADER_LENGTH + 1)) {
-            throw new Error('Chunk size must be at least ' + (Common.HEADER_LENGTH + 1));
+    protected constructor(
+        mode: Mode, headerLength: number, id: number | null, message: Uint8Array, chunkLength: number,
+        buffer: ArrayBuffer = null,
+    ) {
+        const minChunkSize = headerLength + 1;
+        if (chunkLength < minChunkSize) {
+            throw new Error(`Chunk size must be at least ${minChunkSize}`);
+        }
+        if (buffer !== null && buffer.byteLength < chunkLength) {
+            throw new Error('Buffer too small for chunks');
         }
         if (message.byteLength < 1) {
-            throw new Error('Array may not be empty');
+            throw new Error('Message may not be empty');
         }
-        if (id < 0 || id >= (2 ** 32)) {
+        if (id != null && (id < 0 || id >= (2 ** 32))) {
             throw new Error('Message id must be between 0 and 2**32-1');
         }
+
+        this.mode = mode;
         this.id = id;
         this.message = message;
-        this.chunkDataSize = chunkSize - Common.HEADER_LENGTH;
+        this.headerLength = headerLength;
+        this.payloadLength = chunkLength - headerLength;
+        this.buffer = buffer;
     }
 
     /**
      * Whether there are more chunks available.
      */
     public get hasNext(): boolean {
-        const currentIndex = this.chunkId * this.chunkDataSize;
-        const remaining = this.message.byteLength - currentIndex;
-        return remaining >= 1;
+        return this.offset < this.message.byteLength;
     }
 
     /**
      * Iterator implementation. Value is the next Uint8Array chunk.
+     *
+     * Important: When the chunker has been created with `reuseBuffer` set to `true`, the underlying buffer of the
+     *            chunk will be reused in the next iteration.
      */
     public next(): IteratorResult<Uint8Array> {
         if (!this.hasNext) {
@@ -64,36 +74,43 @@ export class Chunker implements chunkedDc.Chunker {
             };
         }
 
-        // Allocate chunk buffer
-        const currentIndex = this.chunkId * this.chunkDataSize;
-        const remaining = this.message.byteLength - currentIndex;
-        const chunkBytes = remaining < this.chunkDataSize ? remaining : this.chunkDataSize;
-        const chunk = new DataView(new ArrayBuffer(chunkBytes + Common.HEADER_LENGTH));
-
-        // Create header
-        const options = remaining > chunkBytes ? 0 : 1;
-        const id = this.id;
-        const serial = this.nextSerial();
-
-        // Write to chunk buffer
-        chunk.setUint8(0, options);
-        chunk.setUint32(1, id);
-        chunk.setUint32(5, serial);
-        for (let i = 0; i < chunkBytes; i++) {
-            const offset = Common.HEADER_LENGTH + i;
-            chunk.setUint8(offset, this.message[currentIndex + i]);
+        // Allocate chunk buffer (if required)
+        const remaining = this.message.byteLength - this.offset;
+        const payloadLength = remaining < this.payloadLength ? remaining : this.payloadLength;
+        const chunkLength = payloadLength + this.headerLength;
+        const endOffset = this.offset + payloadLength;
+        let chunkBuffer: ArrayBuffer;
+        if (this.buffer !== null) {
+            chunkBuffer = this.buffer;
+        } else {
+            chunkBuffer = new ArrayBuffer(chunkLength);
         }
+
+        // Set header
+        const chunkView = new DataView(chunkBuffer);
+        let options: number = this.mode;
+        if (endOffset === this.message.byteLength) {
+            options |= 1;
+        }
+        chunkView.setUint8(0, options);
+        switch (this.mode) {
+            case Mode.ReliableOrdered:
+                break;
+            case Mode.UnreliableUnordered:
+                chunkView.setUint32(1, this.id);
+                chunkView.setUint32(5, this.serial++);
+                break;
+        }
+
+        // Set payload
+        const payloadSlice = this.message.subarray(this.offset, endOffset);
+        const chunkArray = new Uint8Array(chunkBuffer);
+        chunkArray.set(payloadSlice, this.headerLength);
+        this.offset = endOffset;
         return {
             done: false,
-            value: new Uint8Array(chunk.buffer),
+            value: chunkArray,
         };
-    }
-
-    /**
-     * Return and post-increment the id of the next block
-     */
-    private nextSerial(): number {
-        return this.chunkId++;
     }
 
     /**
@@ -102,5 +119,39 @@ export class Chunker implements chunkedDc.Chunker {
     public [Symbol.iterator](): IterableIterator<Uint8Array> {
         return this;
     }
+}
 
+export class ReliableOrderedChunker extends AbstractChunker implements chunkedDc.ReliableOrderedChunker {
+    /**
+     * Create a chunker for reliable & ordered mode.
+     *
+     * @param message The Uint8Array containing the bytes that should be chunked.
+     * @param chunkLength The chunk size *including* header data.
+     * @param buffer A chunk buffer to be used for handing out chunks. Must be
+     *   able to at least contain `chunkLength` bytes. A new buffer will be
+     *   created for every chunk if not supplied.
+     * @throws Error if a chunk would not fit into the specified chunk length,
+     *   if the message is empty, and if the message id is too large.
+     */
+    public constructor(message: Uint8Array, chunkLength: number, buffer?: ArrayBuffer) {
+        super(Mode.ReliableOrdered, RELIABLE_ORDERED_HEADER_LENGTH, null, message, chunkLength, buffer);
+    }
+}
+
+export class UnreliableUnorderedChunker extends AbstractChunker implements chunkedDc.UnreliableUnorderedChunker {
+    /**
+     * Create a chunker for reliable & ordered mode.
+     *
+     * @param id An identifier for the message. Must be between 0 and 2**32-1.
+     * @param message The Uint8Array containing the bytes that should be chunked.
+     * @param chunkLength The chunk size *including* header data.
+     * @param buffer A chunk buffer to be used for handing out chunks. Must be
+     *   able to at least contain `chunkLength` bytes. A new buffer will be
+     *   created for every chunk if not supplied.
+     * @throws Error if a chunk would not fit into the specified chunk length,
+     *   if the message is empty, and if the message id is too large.
+     */
+    public constructor(id: number, message: Uint8Array, chunkLength: number, buffer?: ArrayBuffer) {
+        super(Mode.UnreliableUnordered, UNRELIABLE_UNORDERED_HEADER_LENGTH, id, message, chunkLength, buffer);
+    }
 }

--- a/src/chunker.ts
+++ b/src/chunker.ts
@@ -78,7 +78,7 @@ abstract class AbstractChunker implements chunkedDc.Chunker {
         // Allocate chunk buffer (if required)
         const remaining = this.message.byteLength - this.offset;
         const payloadLength = remaining < this.payloadLength ? remaining : this.payloadLength;
-        const chunkLength = payloadLength + this.headerLength;
+        const chunkLength = this.headerLength + payloadLength;
         const endOffset = this.offset + payloadLength;
         let chunkBuffer: ArrayBuffer;
         if (this.buffer !== null) {
@@ -105,7 +105,7 @@ abstract class AbstractChunker implements chunkedDc.Chunker {
 
         // Set payload
         const payloadSlice = this.message.subarray(this.offset, endOffset);
-        const chunkArray = new Uint8Array(chunkBuffer);
+        const chunkArray = new Uint8Array(chunkBuffer, 0, chunkLength);
         chunkArray.set(payloadSlice, this.headerLength);
         this.offset = endOffset;
         return {

--- a/src/chunker.ts
+++ b/src/chunker.ts
@@ -91,7 +91,7 @@ abstract class AbstractChunker implements chunkedDc.Chunker {
         const chunkView = new DataView(chunkBuffer);
         let options: number = this.mode;
         if (endOffset === this.message.byteLength) {
-            options |= 1;
+            options |= 1; // tslint:disable-line:no-bitwise
         }
         chunkView.setUint8(0, options);
         switch (this.mode) {

--- a/src/chunker.ts
+++ b/src/chunker.ts
@@ -63,8 +63,9 @@ abstract class AbstractChunker implements chunkedDc.Chunker {
     /**
      * Iterator implementation. Value is the next Uint8Array chunk.
      *
-     * Important: When the chunker has been created with `reuseBuffer` set to `true`, the underlying buffer of the
-     *            chunk will be reused in the next iteration.
+     * Important: When the chunker has been created with an `ArrayBuffer`,
+     *            the underlying buffer of the chunk will be reused in the next
+     *            iteration.
      */
     public next(): IteratorResult<Uint8Array> {
         if (!this.hasNext) {

--- a/src/common.ts
+++ b/src/common.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2018 Threema GmbH / SaltyRTC Contributors
+ * Copyright (C) 2016-2019 Threema GmbH / SaltyRTC Contributors
  *
  * Licensed under the Apache License, Version 2.0, <see LICENSE-APACHE file>
  * or the MIT license <see LICENSE-MIT file>, at your option. This file may not be

--- a/src/common.ts
+++ b/src/common.ts
@@ -13,7 +13,7 @@ export const UNRELIABLE_UNORDERED_HEADER_LENGTH = 9;
  * The mode being used when chunking/unchunking.
  */
 export const MODE_BITMASK = 6;
-export enum Mode {
+export const enum Mode {
     // Important: Changes to the values must correspond to the options field!
 
     // R R R R R 1 1 E

--- a/src/common.ts
+++ b/src/common.ts
@@ -5,6 +5,19 @@
  * or the MIT license <see LICENSE-MIT file>, at your option. This file may not be
  * copied, modified, or distributed except according to those terms.
  */
-export class Common {
-    public static HEADER_LENGTH = 9;
+
+export const RELIABLE_ORDERED_HEADER_LENGTH = 1;
+export const UNRELIABLE_UNORDERED_HEADER_LENGTH = 9;
+
+/**
+ * The mode being used when chunking/unchunking.
+ */
+export const MODE_BITFIELD = 6;
+export enum Mode {
+    // Important: Changes to the values must correspond to the options field!
+
+    // R R R R R 1 1 E
+    ReliableOrdered = 6,
+    // R R R R R 0 0 E
+    UnreliableUnordered = 0,
 }

--- a/src/common.ts
+++ b/src/common.ts
@@ -12,7 +12,7 @@ export const UNRELIABLE_UNORDERED_HEADER_LENGTH = 9;
 /**
  * The mode being used when chunking/unchunking.
  */
-export const MODE_BITFIELD = 6;
+export const MODE_BITMASK = 6;
 export enum Mode {
     // Important: Changes to the values must correspond to the options field!
 

--- a/src/main.es5.ts
+++ b/src/main.es5.ts
@@ -9,5 +9,5 @@ import '../node_modules/@babel/polyfill/dist/polyfill'; // Include ES5 polyfills
 export {
     ReliableOrderedChunker, UnreliableUnorderedChunker,
     ReliableOrderedUnchunker, UnreliableUnorderedUnchunker,
-    UNRELIABLE_UNORDERED_HEADER_LENGTH, RELIABLE_ORDERED_HEADER_LENGTH, Mode
+    UNRELIABLE_UNORDERED_HEADER_LENGTH, RELIABLE_ORDERED_HEADER_LENGTH, Mode,
 } from './main';

--- a/src/main.es5.ts
+++ b/src/main.es5.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2018 Threema GmbH / SaltyRTC Contributors
+ * Copyright (C) 2016-2019 Threema GmbH / SaltyRTC Contributors
  *
  * Licensed under the Apache License, Version 2.0, <see LICENSE-APACHE file>
  * or the MIT license <see LICENSE-MIT file>, at your option. This file may not be

--- a/src/main.es5.ts
+++ b/src/main.es5.ts
@@ -6,4 +6,8 @@
  * copied, modified, or distributed except according to those terms.
  */
 import '../node_modules/@babel/polyfill/dist/polyfill'; // Include ES5 polyfills
-export { Chunker, Unchunker } from './main';
+export {
+    ReliableOrderedChunker, UnreliableUnorderedChunker,
+    ReliableOrderedUnchunker, UnreliableUnorderedUnchunker,
+    UNRELIABLE_UNORDERED_HEADER_LENGTH, RELIABLE_ORDERED_HEADER_LENGTH, Mode
+} from './main';

--- a/src/main.ts
+++ b/src/main.ts
@@ -5,11 +5,8 @@
  * or the MIT license <see LICENSE-MIT file>, at your option. This file may not be
  * copied, modified, or distributed except according to those terms.
  */
-import { Common } from './common';
+export { UNRELIABLE_UNORDERED_HEADER_LENGTH, RELIABLE_ORDERED_HEADER_LENGTH, Mode } from './common';
 
 // Export classes
-export { Chunker } from './chunker';
-export { Unchunker } from './unchunker';
-
-// Export constants
-export const HEADER_LENGTH = Common.HEADER_LENGTH;
+export { ReliableOrderedChunker, UnreliableUnorderedChunker } from './chunker';
+export { ReliableOrderedUnchunker, UnreliableUnorderedUnchunker } from './unchunker';

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2018 Threema GmbH / SaltyRTC Contributors
+ * Copyright (C) 2016-2019 Threema GmbH / SaltyRTC Contributors
  *
  * Licensed under the Apache License, Version 2.0, <see LICENSE-APACHE file>
  * or the MIT license <see LICENSE-MIT file>, at your option. This file may not be

--- a/src/unchunker.ts
+++ b/src/unchunker.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2018 Threema GmbH / SaltyRTC Contributors
+ * Copyright (C) 2016-2019 Threema GmbH / SaltyRTC Contributors
  *
  * Licensed under the Apache License, Version 2.0, <see LICENSE-APACHE file>
  * or the MIT license <see LICENSE-MIT file>, at your option. This file may not be

--- a/src/unchunker.ts
+++ b/src/unchunker.ts
@@ -46,7 +46,7 @@ export class Chunk {
                 this.serial = chunkView.getUint32(5);
                 break;
         }
-        this.endOfMessage = (options & 1) === 1; // tslint:disable-line:no-bitwise;
+        this.endOfMessage = (options & 1) === 1; // tslint:disable-line:no-bitwise
 
         // Store payload
         this.payload = chunkArray.subarray(headerLength);
@@ -368,7 +368,6 @@ export class ReliableOrderedUnchunker extends AbstractUnchunker implements chunk
         }
     }
 }
-
 
 /**
  * A reassembler optimised for unreliable & unordered mode.

--- a/src/unchunker.ts
+++ b/src/unchunker.ts
@@ -143,7 +143,6 @@ class ContiguousBufferReassembler {
             this.buffer = new ArrayBuffer(length);
             this.array = new Uint8Array(this.buffer);
             this.array.set(previousArray);
-            this.offset = previousArray.byteLength;
             this.remaining = length - this.offset;
         }
     }

--- a/src/unchunker.ts
+++ b/src/unchunker.ts
@@ -7,7 +7,7 @@
  */
 /// <reference path='../chunked-dc.d.ts' />
 
-import { Mode, MODE_BITFIELD, RELIABLE_ORDERED_HEADER_LENGTH, UNRELIABLE_UNORDERED_HEADER_LENGTH } from './common';
+import { Mode, MODE_BITMASK, RELIABLE_ORDERED_HEADER_LENGTH, UNRELIABLE_UNORDERED_HEADER_LENGTH } from './common';
 
 /**
  * Helper class to store chunk information.
@@ -19,9 +19,9 @@ export class Chunk {
     public readonly payload: Uint8Array;
 
     /**
-     * Parse the chunk's buffer.
+     * Parse the chunk.
      *
-     * @param chunkArray The chunk's buffer which will be **referenced**.
+     * @param chunkArray The chunk's array which will be **referenced**.
      * @param expectedMode The mode we expect the chunk to use.
      * @param headerLength The expected header length.
      * @throws Error if message is smaller than the header length or an unexpected mode has been detected.
@@ -34,7 +34,7 @@ export class Chunk {
         // Read header
         const chunkView = new DataView(chunkArray.buffer, chunkArray.byteOffset, chunkArray.byteLength);
         const options = chunkView.getUint8(0);
-        const actualMode = (options & MODE_BITFIELD); // tslint:disable-line:no-bitwise
+        const actualMode = (options & MODE_BITMASK); // tslint:disable-line:no-bitwise
         if (actualMode !== expectedMode) {
             throw new Error(`Invalid chunk: Unexpected mode ${actualMode}`);
         }

--- a/src/unchunker.ts
+++ b/src/unchunker.ts
@@ -7,241 +7,343 @@
  */
 /// <reference path='../chunked-dc.d.ts' />
 
-import { Common } from './common';
+import { Mode, MODE_BITFIELD, RELIABLE_ORDERED_HEADER_LENGTH, UNRELIABLE_UNORDERED_HEADER_LENGTH } from './common';
 
 /**
- * Helper class to access chunk information.
+ * Helper class to store chunk information.
  */
 export class Chunk {
-    private _endOfMessage: boolean;
-    private _id: number;
-    private _serial: number;
-    private _data: Uint8Array;
-    private _context: any;
+    public readonly endOfMessage: boolean;
+    public readonly id: number;
+    public readonly serial: number;
+    public readonly payload: Uint8Array;
 
     /**
-     * Parse the ArrayBuffer.
+     * Parse the chunk's buffer.
+     *
+     * @param chunkArray The chunk's buffer which will be **referenced**.
+     * @param expectedMode The mode we expect the chunk to use.
+     * @param headerLength The expected header length.
+     * @throws Error if message is smaller than the header length or an unexpected mode has been detected.
      */
-    constructor(buf: ArrayBuffer, context?: any) {
-        if (buf.byteLength < Common.HEADER_LENGTH) {
+    public constructor(chunkArray: Uint8Array, expectedMode: Mode, headerLength: number) {
+        if (chunkArray.byteLength < headerLength) {
             throw new Error('Invalid chunk: Too short');
         }
 
         // Read header
-        const reader = new DataView(buf);
-        const options = reader.getUint8(0);
-        // tslint:disable-next-line:no-bitwise
-        this._endOfMessage = (options & 0x01) === 1;
-        this._id = reader.getUint32(1);
-        this._serial = reader.getUint32(5);
+        const chunkView = new DataView(chunkArray.buffer, chunkArray.byteOffset, chunkArray.byteLength);
+        const options = chunkView.getUint8(0);
+        const actualMode = (options & MODE_BITFIELD); // tslint:disable-line:no-bitwise
+        if (actualMode !== expectedMode) {
+            throw new Error(`Invalid chunk: Unexpected mode ${actualMode}`);
+        }
+        switch (expectedMode) {
+            case Mode.ReliableOrdered:
+                break;
+            case Mode.UnreliableUnordered:
+                this.id = chunkView.getUint32(1);
+                this.serial = chunkView.getUint32(5);
+                break;
+        }
+        this.endOfMessage = (options & 1) === 1; // tslint:disable-line:no-bitwise;
 
-        // Read data
-        // Note: We copy the data bytes instead of getting a reference to a subset of the buffer.
-        // This is less ideal for performance, but avoids bugs that can occur
-        // by 3rd party modification of the ArrayBuffer.
-        this._data = new Uint8Array(buf.slice(Common.HEADER_LENGTH));
-
-        // Store context
-        this._context = context;
-    }
-
-    public get isEndOfMessage(): boolean {
-        return this._endOfMessage;
-    }
-
-    public get id(): number {
-        return this._id;
-    }
-
-    public get serial(): number {
-        return this._serial;
-    }
-
-    public get data(): Uint8Array {
-        return this._data;
-    }
-
-    public get context(): any {
-        return this._context;
+        // Store payload
+        this.payload = chunkArray.subarray(headerLength);
     }
 }
 
 /**
- * Helper class to hold chunks and an "end-arrived" flag.
+ * Copies chunks into a contiguous buffer.
  */
-class ChunkCollector {
-    private endArrived: boolean;
-    private messageLength: number = null;
-    private chunks: Chunk[] = [];
-    private lastUpdate: number = new Date().getTime();
+class ContiguousBufferReassembler {
+    private buffer: Uint8Array | null = null;
+    private offset: number = 0;
+    private remaining: number = 0;
+
+    public get empty(): boolean {
+        return this.buffer === null;
+    }
 
     /**
-     * Register a new chunk. Return a boolean indicating whether the chunk was added.
+     * Append a chunk in the internal buffer.
+     *
+     * @param chunk The chunk to be appended.
      */
-    public addChunk(chunk: Chunk): void {
-        // Ignore repeated chunks with the same serial
-        if (this.hasSerial(chunk.serial)) {
-            return;
-        }
+    public add(chunk: Chunk): void {
+        const chunkLength = chunk.payload.byteLength;
+        this.prepareFor(chunkLength);
+        this.buffer.set(chunk.payload, this.offset);
+        this.offset += chunkLength;
+        this.remaining -= chunkLength;
+    }
 
-        // Add chunk
-        this.chunks.push(chunk);
-
-        // Process chunk
-        this.lastUpdate = new Date().getTime();
-        if (chunk.isEndOfMessage) {
-            this.endArrived = true;
-            this.messageLength = chunk.serial + 1;
+    /**
+     * Prepare the internal buffer so a new chunk can be safely added.
+     *
+     * Note: We apply a heuristic here to double the buffer's size, so we don't
+     *       need to create new buffers and copy every time. This should be
+     *       faster than merging at the end since we can expect that the local
+     *       machine copies memory faster than it will receive new chunks.
+     *
+     * @param chunkLength The chunk's byte length.
+     */
+    private prepareFor(chunkLength: number): void {
+        if (this.buffer === null) {
+            this.buffer = new Uint8Array(chunkLength);
+        } else if (this.remaining < chunkLength) {
+            const previousBuffer = this.buffer;
+            const length = Math.max(previousBuffer.byteLength * 2, previousBuffer.byteLength + chunkLength);
+            this.buffer = new Uint8Array(length);
+            this.buffer.set(previousBuffer);
+            this.offset = previousBuffer.byteLength;
+            this.remaining = length - this.offset;
         }
     }
 
     /**
-     * Return whether this chunk collector already contains a chunk with the specified serial.
+     * Extract the complete message from the internal buffer.
+     *
+     * @return The completed message.
      */
-    public hasSerial(serial: number): boolean {
-        return this.chunks.find(
-            (chunk: Chunk) => chunk.serial === serial,
-        ) !== undefined;
+    public getMessage(): Uint8Array {
+        const message = this.buffer.subarray(0, this.offset);
+        this.buffer = null;
+        this.offset = 0;
+        this.remaining = 0;
+        return message;
+    }
+}
+
+/**
+ * Reorders chunks and then copies them into a contiguous buffer.
+ */
+class UnreliableUnorderedReassembler {
+    private readonly contiguousChunks: ContiguousBufferReassembler = new ContiguousBufferReassembler();
+    private queuedChunks: Chunk[] | null = null;
+    private _chunkCount: number = 0;
+    private nextOrderedSerial: number = 0;
+    private lastUpdate: number = new Date().getTime();
+    private requiredChunkCount: number | null = null;
+
+    /**
+     * Return the number of added chunks.
+     */
+    public get chunkCount(): number {
+        return this._chunkCount;
     }
 
     /**
      * Return whether the message is complete, meaning that all chunks of the message arrived.
      */
-    public get isComplete() {
-        return this.endArrived && this.chunks.length === this.messageLength;
+    public get complete() {
+        return this.requiredChunkCount !== null && this._chunkCount === this.requiredChunkCount;
     }
 
     /**
-     * Merge the messages.
-     *
-     * Note: This implementation assumes that no chunk will be larger than the first one!
-     * If this is not the case, an error may be thrown.
-     *
-     * @return An object containing the message as an `Uint8Array`
-     *         and a (possibly empty) list of context objects.
-     * @throws Error if message is not yet complete.
+     * Add a new chunk.
      */
-    public merge(): {message: Uint8Array, context: any[]} {
-        // Preconditions
-        if (!this.isComplete) {
-            throw new Error('Not all chunks for this message have arrived yet.');
+    public add(chunk: Chunk): void {
+        if (this.queuedChunks === null && chunk.serial === this._chunkCount) {
+            // In order: Can be added to the contiguous chunks
+            this.contiguousChunks.add(chunk);
+            this.nextOrderedSerial = chunk.serial + 1;
+        } else {
+            // Out of order: Needs to be temporarily stored in a queue
+            const ready = this.queueUnorderedChunk(chunk);
+            if (ready) {
+                // Queue is ready to be moved into the contiguous buffer.
+                this.moveQueuedChunks();
+            }
         }
 
-        // Sort chunks
-        this.chunks.sort((a: Chunk, b: Chunk) => {
+        // Check if this is the last chunk received
+        if (chunk.endOfMessage) {
+            this.requiredChunkCount = chunk.serial + 1;
+        }
+
+        // Update chunk counter and timestamp
+        ++this._chunkCount;
+        this.lastUpdate = new Date().getTime();
+    }
+
+    /**
+     * Add a new chunk to its intended position in the out-of-order queue.
+     *
+     * Note: We continuously sort the queue by the serial number (ascending).
+     *
+     * @returns whether the queue is ready to be moved into the contiguous buffer.
+     */
+    private queueUnorderedChunk(chunk: Chunk): boolean {
+        // Append chunk
+        if (this.queuedChunks === null) {
+            this.queuedChunks = [chunk];
+            return false;
+        }
+        this.queuedChunks.push(chunk);
+
+        // Sort chunk queue
+        this.queuedChunks.sort((a: Chunk, b: Chunk) => {
             if (a.serial < b.serial) {
                 return -1;
-            } else if (a.serial > b.serial) {
+            }
+            if (a.serial > b.serial) {
                 return 1;
             }
             return 0;
         });
 
-        // Allocate buffer
-        const capacity = this.chunks[0].data.byteLength * this.messageLength;
-        const buf = new Uint8Array(new ArrayBuffer(capacity));
-
-        // Add chunks to buffer
-        let offset = 0;
-        const firstSize = this.chunks[0].data.byteLength;
-        const contextList = [];
-        for (const chunk of this.chunks) {
-            if (chunk.data.byteLength > firstSize) {
-                throw new Error('No chunk may be larger than the first chunk of that message.');
-            }
-            buf.set(chunk.data, offset);
-            offset += chunk.data.length;
-            if (chunk.context !== undefined) {
-                contextList.push(chunk.context);
-            }
+        // Check if ready
+        const iterator = this.queuedChunks.values();
+        let previousChunk = iterator.next().value;
+        if (previousChunk.serial !== this.nextOrderedSerial) {
+            return false;
         }
-
-        // Return result object
-        return {
-            message: buf.slice(0, offset),
-            context: contextList,
-        };
+        for (const currentChunk of iterator) {
+            if (previousChunk.serial + 1 !== currentChunk.serial) {
+                return false;
+            }
+            previousChunk = currentChunk;
+        }
+        return true;
     }
 
     /**
-     * Return whether last chunk is older than the specified number of miliseconds.
+     * Moves the queued chunks to the contiguous buffer.
+     *
+     * Should be called once the queue contains consecutive chunks and there is
+     * no gap between the contiguous chunk buffer and our queued chunks.
+     */
+    private moveQueuedChunks(): void {
+        let chunk: Chunk;
+        for (chunk of this.queuedChunks) {
+            this.contiguousChunks.add(chunk);
+        }
+        // Note: `chunk` is the last chunk in the sequence and has the highest serial number
+        this.nextOrderedSerial = chunk.serial + 1;
+        this.queuedChunks = null;
+    }
+
+    /**
+     * Get the reassembled message.
+     *
+     * @return The completed message.
+     */
+    public getMessage(): Uint8Array {
+        return this.contiguousChunks.getMessage();
+    }
+
+    /**
+     * Return whether last chunk is older than the specified number of milliseconds.
      */
     public isOlderThan(maxAge: number): boolean {
         const age = (new Date().getTime() - this.lastUpdate);
         return age > maxAge;
     }
-
-    /**
-     * Return the number of registered chunks.
-     */
-    public get chunkCount(): number {
-        return this.chunks.length;
-    }
 }
 
 /**
- * An Unchunker instance merges multiple chunks into a single Uint8Array.
- *
- * It keeps track of IDs, so only one Unchunker instance is necessary
- * to receive multiple messages.
+ * An unchunker reassembles multiple chunks into a single message.
  */
-export class Unchunker {
-    private chunks: Map<number, ChunkCollector> = new Map();
-
+abstract class AbstractUnchunker implements chunkedDc.Unchunker {
     /**
      * Message listener. Set by the user.
      */
-    public onMessage: (message: Uint8Array, context?: any[]) => void = null;
+    public onMessage: (message: Uint8Array) => void = null;
+
+    /**
+     * Notify message listener about a complete message.
+     */
+    protected notifyListener(message: Uint8Array) {
+        if (this.onMessage != null) {
+            this.onMessage(message);
+        }
+    }
 
     /**
      * Add a chunk.
      *
-     * @param buf ArrayBuffer containing chunk with 9 byte header.
-     * @param context Arbitrary data that will be registered with the chunk and will be passed to the callback.
-     * @throws Error if message is smaller than the header length.
+     * @param chunkArray A chunk containing either a 1 byte or 9 byte header.
+     *   Important: The chunk's underlying buffer should be considered transferred!
+     * @throws Error if message is smaller than the header length or an unknown
+     *   mode has been detected.
      */
-    public add(buf: ArrayBuffer, context?: any): void {
-        // Parse chunk
-        const chunk = new Chunk(buf, context);
+    public abstract add(chunkArray: Uint8Array): void;
+}
 
-        // Ignore repeated chunks with the same serial
-        if (this.chunks.has(chunk.id) && this.chunks.get(chunk.id).hasSerial(chunk.serial)) {
-            return;
-        }
-
-        // If this is the only chunk in the message, return it immediately.
-        if (chunk.isEndOfMessage && chunk.serial === 0) {
-            this.notifyListener(chunk.data, context === undefined ? [] : [context]);
-            this.chunks.delete(chunk.id);
-            return;
-        }
-
-        // Otherwise, add chunk to chunks list
-        let collector: ChunkCollector;
-        if (this.chunks.has(chunk.id)) {
-            collector = this.chunks.get(chunk.id);
-        } else {
-            collector = new ChunkCollector();
-            this.chunks.set(chunk.id, collector);
-        }
-        collector.addChunk(chunk);
-
-        // Check if message is complete
-        if (collector.isComplete) {
-            // Merge and notify listener...
-            const merged = collector.merge();
-            this.notifyListener(merged.message, merged.context);
-            // ...then delete the chunks.
-            this.chunks.delete(chunk.id);
-        }
-    }
+/**
+ * An unchunker for reliable & ordered mode.
+ */
+export class ReliableOrderedUnchunker extends AbstractUnchunker implements chunkedDc.ReliableOrderedUnchunker {
+    private readonly reassembler: ContiguousBufferReassembler = new ContiguousBufferReassembler();
 
     /**
-     * If a message listener is set, notify it about a complete message.
+     * Add a chunk.
+     *
+     * @param chunkArray A chunk containing a 1 byte header.
+     *   Important: The chunk's underlying buffer should be considered transferred!
+     * @throws Error if message is smaller than the header length or an unknown
+     *   mode has been detected.
      */
-    private notifyListener(message: Uint8Array, context: any[]) {
-        if (this.onMessage != null) {
-            this.onMessage(message, context);
+    public add(chunkArray: Uint8Array): void {
+        // Parse chunk
+        const chunk = new Chunk(chunkArray, Mode.ReliableOrdered, RELIABLE_ORDERED_HEADER_LENGTH);
+
+        // If this is a single chunk that contains the whole message, return it immediately.
+        if (this.reassembler.empty && chunk.endOfMessage) {
+            this.notifyListener(chunk.payload);
+            return;
+        }
+
+        // Add the chunk's payload to the message buffer.
+        this.reassembler.add(chunk);
+
+        // Check if message is complete
+        if (chunk.endOfMessage) {
+            // Hand out the message and reset the buffer
+            this.notifyListener(this.reassembler.getMessage());
+        }
+    }
+}
+
+
+/**
+ * A reassembler optimised for unreliable & unordered mode.
+ */
+export class UnreliableUnorderedUnchunker extends AbstractUnchunker implements chunkedDc.UnreliableUnorderedUnchunker {
+    private reassemblers: Map<number, UnreliableUnorderedReassembler> = new Map();
+
+    /**
+     * Add a chunk.
+     *
+     * @param chunkArray A chunk containing a 9 byte header.
+     *   Important: The chunk's underlying buffer should be considered transferred!
+     * @throws Error if message is smaller than the header length or an unknown
+     *   mode has been detected.
+     */
+    public add(chunkArray: Uint8Array): void {
+        // Parse chunk
+        const chunk = new Chunk(chunkArray, Mode.UnreliableUnordered, UNRELIABLE_UNORDERED_HEADER_LENGTH);
+
+        // If this is a single chunk that contains the whole message, return it immediately.
+        if (chunk.endOfMessage && chunk.serial === 0) {
+            this.notifyListener(chunk.payload);
+            return;
+        }
+
+        // Add chunk to reassembler
+        let reassembler: UnreliableUnorderedReassembler = this.reassemblers.get(chunk.id);
+        if (reassembler === undefined) {
+            reassembler = new UnreliableUnorderedReassembler();
+            this.reassemblers.set(chunk.id, reassembler);
+        }
+        reassembler.add(chunk);
+
+        // Check if message is complete
+        if (reassembler.complete) {
+            // Hand out the message and delete the message's reassembler
+            this.notifyListener(reassembler.getMessage());
+            this.reassemblers.delete(chunk.id);
         }
     }
 
@@ -254,18 +356,15 @@ export class Unchunker {
      *
      * @param maxAge Remove incomplete messages that haven't been updated for
      *               more than the specified number of milliseconds.
-     * @return the number of removed chunks.
      */
     public gc(maxAge: number): number {
-        let removedItems = 0;
-        for (const entry of this.chunks) {
-            const msgId: number = entry[0];
-            const collector: ChunkCollector = entry[1];
-            if (collector.isOlderThan(maxAge)) {
-                removedItems += collector.chunkCount;
-                this.chunks.delete(msgId);
+        let removed = 0;
+        for (const [id, reassembler] of this.reassemblers) {
+            if (reassembler.isOlderThan(maxAge)) {
+                removed += reassembler.chunkCount;
+                this.reassemblers.delete(id);
             }
         }
-        return removedItems;
+        return removed;
     }
 }

--- a/tests/performance.ts
+++ b/tests/performance.ts
@@ -9,46 +9,262 @@ import {
 let counter = 1;
 beforeEach(() => console.info('------ TEST', counter++, 'BEGIN ------'));
 
-function generate(messageSize: number, chunkSize: number) {
-    const buffer = new ArrayBuffer(messageSize); // 10 MiB
+type PartialTest = {
+    iterations: number,
+    messageLength: number,
+    chunkLength: number,
+}
+
+type Test = {
+    iterations: number,
+    messageLength: number,
+    chunkLength: number,
+    message: Uint8Array,
+    reliableOrderedChunks: Array<Uint8Array>,
+    unreliableUnorderedChunks: Array<Uint8Array>,
+    shuffledUnreliableUnorderedChunks: Array<Uint8Array>,
+}
+
+function generate(partial: PartialTest): Test {
+    const test = partial as Test;
+    const buffer = new ArrayBuffer(test.messageLength);
     const view = new DataView(buffer);
     for (let i = 0; i < buffer.byteLength; ++i) {
         view.setUint8(i, i % 256);
     }
-    const message = new Uint8Array(buffer);
-    const reliableOrderedChunks = Array.from(
-        new ReliableOrderedChunker(message, chunkSize));
-    const unreliableUnorderedChunks = Array.from(
-        new UnreliableUnorderedChunker(42, message, chunkSize));
-    return [
-        message,
-        reliableOrderedChunks,
-        unreliableUnorderedChunks,
-        shuffle(unreliableUnorderedChunks.slice(0), 0.290193899574423),
-    ];
+    test.message = new Uint8Array(buffer);
+    test.reliableOrderedChunks = Array.from(
+        new ReliableOrderedChunker(test.message, test.chunkLength));
+    test.unreliableUnorderedChunks = Array.from(
+        new UnreliableUnorderedChunker(42, test.message, test.chunkLength));
+    test.shuffledUnreliableUnorderedChunks = shuffle(test.unreliableUnorderedChunks.slice(), 0.290193899574423);
+    return test;
 }
 
 const tests = [
-    [100, 10485760, 16384],
-    [100, 10485760, 65536],
-    [100, 10485760, 262144],
-].map(([iterations, messageSize, chunkSize]: [number, number, number]) => {
-    return [iterations, messageSize, chunkSize, generate(messageSize, chunkSize)];
+    { iterations: 100, messageLength: 10485760, chunkLength: 16384 },
+    { iterations: 100, messageLength: 10485760, chunkLength: 65536 },
+    { iterations: 100, messageLength: 10485760, chunkLength: 262144 },
+].map((test: PartialTest) => generate(test));
+
+describe('Uint8Array performance', () => {
+    {
+        const description = '100 x direct construction with capacity of 10 MiB';
+        it(description, () => {
+            const start = performance.now();
+            for (let i = 0; i < 1000; ++i) {
+                const array = new Uint8Array(10485760);
+                array[0] = 0xff;
+            }
+            const end = performance.now();
+            console.info(description, `Took ${(end - start) / 1000} seconds`);
+            expect(0).toBe(0);
+        });
+    }
+
+    {
+        const description = '100 x construction via ArrayBuffer with capacity of 10 MiB';
+        it(description, () => {
+            const start = performance.now();
+            for (let i = 0; i < 1000; ++i) {
+                const array = new Uint8Array(new ArrayBuffer(10485760));
+                array[0] = 0xff;
+            }
+            const end = performance.now();
+            console.info(description, `Took ${(end - start) / 1000} seconds`);
+            expect(0).toBe(0);
+        });
+    }
+
+    {
+        const description = '100 x copying (.slice) with capacity of 10 MiB';
+        it(description, () => {
+            const data = new Uint8Array(10485760);
+            const start = performance.now();
+            for (let i = 0; i < 1000; ++i) {
+                const copy = data.slice(0);
+                copy[0] = 0xff;
+            }
+            const end = performance.now();
+            console.info(description, `Took ${(end - start) / 1000} seconds`);
+            expect(0).toBe(0);
+        });
+    }
+
+    {
+        const description = '100 x copying (new Uint8Array) with capacity of 10 MiB';
+        it(description, () => {
+            const data = new Uint8Array(10485760);
+            const start = performance.now();
+            for (let i = 0; i < 1000; ++i) {
+                const copy = new Uint8Array(data);
+                copy[0] = 0xff;
+            }
+            const end = performance.now();
+            console.info(description, `Took ${(end - start) / 1000} seconds`);
+            expect(0).toBe(0);
+        });
+    }
+
+    {
+        const description = '100 x copying (.set) with capacity of 10 MiB';
+        it(description, () => {
+            const data = new Uint8Array(10485760);
+            const start = performance.now();
+            for (let i = 0; i < 1000; ++i) {
+                const newData = new Uint8Array(10485760);
+                newData.set(data, 0);
+            }
+            const end = performance.now();
+            console.info(description, `Took ${(end - start) / 1000} seconds`);
+            expect(0).toBe(0);
+        });
+    }
+
+    {
+        const description = '100 x viewing (.subarray) with capacity of 10 MiB';
+        it(description, () => {
+            const data = new Uint8Array(10485760);
+            const start = performance.now();
+            for (let i = 0; i < 1000; ++i) {
+                data.subarray(0, data.byteLength);
+            }
+            const end = performance.now();
+            console.info(description, `Took ${(end - start) / 1000} seconds`);
+            expect(0).toBe(0);
+        });
+    }
+
+    for (const test of tests) {
+        const chunks = test.reliableOrderedChunks;
+        const totalChunkLength = chunks.length * test.chunkLength;
+
+        {
+            const description = `100x copying ${chunks.length} x ~${test.chunkLength / 1024} KiB chunks into a ` +
+                `contiguous buffer of ${totalChunkLength / 1048576} MiB (omniscient buffer)`;
+            it(description, () => {
+                const start = performance.now();
+
+                for (let i = 0; i < 100; ++i) {
+                    const array = new Uint8Array(totalChunkLength);
+                    let offset = 0;
+                    for (const chunk of chunks) {
+                        array.set(chunk, offset);
+                        offset += chunk.byteLength;
+                    }
+                }
+
+                const end = performance.now();
+                console.info(description, `Took ${(end - start) / 1000} seconds`);
+                expect(0).toBe(0);
+            });
+        }
+
+        {
+            const description = `100x copying ${chunks.length} x ~${test.chunkLength / 1024} KiB chunks into a ` +
+                `contiguous buffer of ${totalChunkLength / 1048576} MiB (double array length if chunk does not fit)`;
+            it(description, () => {
+                const start = performance.now();
+
+                for (let i = 0; i < 100; ++i) {
+                    let array = new Uint8Array(test.chunkLength);
+                    let offset = 0;
+                    let remaining = array.byteLength;
+                    for (const chunk of chunks) {
+                        if (remaining < chunk.byteLength) {
+                            const previousArray = array;
+                            const length = previousArray.byteLength * 2;
+                            array = new Uint8Array(length);
+                            array.set(previousArray);
+                            offset = previousArray.byteLength;
+                            remaining = length - offset;
+                        }
+                        array.set(chunk, offset);
+                        offset += chunk.byteLength;
+                        remaining -= chunk.byteLength;
+                    }
+                }
+
+                const end = performance.now();
+                console.info(description, `Took ${(end - start) / 1000} seconds`);
+                expect(0).toBe(0);
+            });
+        }
+
+        {
+            const description = `100x copying ${chunks.length} x ~${test.chunkLength / 1024} KiB chunks into a ` +
+                `contiguous buffer of ${totalChunkLength / 1048576} MiB (double pre-allocated buffer length if chunk ` +
+                'does not fit)';
+            it(description, () => {
+                let buffer = new ArrayBuffer(test.chunkLength);
+                const start = performance.now();
+
+                for (let i = 0; i < 100; ++i) {
+                    let array = new Uint8Array(buffer);
+                    let offset = 0;
+                    let remaining = array.byteLength;
+                    for (const chunk of chunks) {
+                        if (remaining < chunk.byteLength) {
+                            const previousArray = array;
+                            const length = previousArray.byteLength * 2;
+                            buffer = new ArrayBuffer(length);
+                            array = new Uint8Array(buffer);
+                            array.set(previousArray);
+                            offset = previousArray.byteLength;
+                            remaining = length - offset;
+                        }
+                        array.set(chunk, offset);
+                        offset += chunk.byteLength;
+                        remaining -= chunk.byteLength;
+                    }
+                }
+
+                const end = performance.now();
+                console.info(description, `Took ${(end - start) / 1000} seconds`);
+                expect(0).toBe(0);
+            });
+        }
+
+        {
+            const description = `100x merging ${chunks.length} x ~${test.chunkLength / 1024} KiB chunks into a ` +
+                `contiguous buffer of ${totalChunkLength / 1048576} MiB`;
+            it(description, () => {
+                const start = performance.now();
+
+                for (let i = 0; i < 100; ++i) {
+                    let length = 0;
+                    const list = [];
+                    for (const chunk of chunks) {
+                        list.push(chunk);
+                        length += chunk.byteLength;
+                    }
+                    const array = new Uint8Array(length);
+                    let offset = 0;
+                    for (const chunk of list) {
+                        array.set(chunk, offset);
+                        offset += chunk.byteLength;
+                    }
+                }
+
+                const end = performance.now();
+                console.info(description, `Took ${(end - start) / 1000} seconds`);
+                expect(0).toBe(0);
+            });
+        }
+    }
 });
 
 describe('Chunker performance', () => {
     describe('ordered (with reused buffer)', () => {
         for (const test of tests) {
-            const [iterations, messageSize, chunkSize, data] = test;
-            const message = data[0];
-            const description = `${iterations} x ${messageSize / 1048576} MiB messages as ` +
-                `${chunkSize / 1024} KiB chunks`;
+            const description = `${test.iterations} x ${test.messageLength / 1048576} MiB messages as ` +
+                `${test.chunkLength / 1024} KiB chunks`;
             it(description, () => {
-                const buffer = new ArrayBuffer(chunkSize);
+                const buffer = new ArrayBuffer(test.chunkLength);
                 const start = performance.now();
 
-                for (let i = 0; i < iterations; ++i) {
-                    const chunker = new ReliableOrderedChunker(message, chunkSize, buffer);
+                for (let i = 0; i < test.iterations; ++i) {
+                    const chunker = new ReliableOrderedChunker(test.message, test.chunkLength, buffer);
                     for (const _ of chunker) {}
                 }
 
@@ -61,15 +277,13 @@ describe('Chunker performance', () => {
 
     describe('ordered (without reused buffer)', () => {
         for (const test of tests) {
-            const [iterations, messageSize, chunkSize, data] = test;
-            const message = data[0];
-            const description = `${iterations} x ${messageSize / 1048576} MiB messages as ` +
-                `${chunkSize / 1024} KiB chunks`;
+            const description = `${test.iterations} x ${test.messageLength / 1048576} MiB messages as ` +
+                `${test.chunkLength / 1024} KiB chunks`;
             it(description, () => {
                 const start = performance.now();
 
-                for (let i = 0; i < iterations; ++i) {
-                    const chunker = new ReliableOrderedChunker(message, chunkSize);
+                for (let i = 0; i < test.iterations; ++i) {
+                    const chunker = new ReliableOrderedChunker(test.message, test.chunkLength);
                     for (const _ of chunker) {}
                 }
 
@@ -82,16 +296,14 @@ describe('Chunker performance', () => {
 
     describe('unordered (with reused buffer)', () => {
         for (const test of tests) {
-            const [iterations, messageSize, chunkSize, data] = test;
-            const message = data[0];
-            const description = `${iterations} x ${messageSize / 1048576} MiB messages as ` +
-                `${chunkSize / 1024} KiB chunks`;
+            const description = `${test.iterations} x ${test.messageLength / 1048576} MiB messages as ` +
+                `${test.chunkLength / 1024} KiB chunks`;
             it(description, () => {
-                const buffer = new ArrayBuffer(chunkSize);
+                const buffer = new ArrayBuffer(test.chunkLength);
                 const start = performance.now();
 
-                for (let i = 0; i < iterations; ++i) {
-                    const chunker = new UnreliableUnorderedChunker(42, message, chunkSize, buffer);
+                for (let i = 0; i < test.iterations; ++i) {
+                    const chunker = new UnreliableUnorderedChunker(42, test.message, test.chunkLength, buffer);
                     for (const _ of chunker) {}
                 }
 
@@ -104,15 +316,13 @@ describe('Chunker performance', () => {
 
     describe('unordered (without reused buffer)', () => {
         for (const test of tests) {
-            const [iterations, messageSize, chunkSize, data] = test;
-            const message = data[0];
-            const description = `${iterations} x ${messageSize / 1048576} MiB messages as ` +
-                `${chunkSize / 1024} KiB chunks`;
+            const description = `${test.iterations} x ${test.messageLength / 1048576} MiB messages as ` +
+                `${test.chunkLength / 1024} KiB chunks`;
             it(description, () => {
                 const start = performance.now();
 
-                for (let i = 0; i < iterations; ++i) {
-                    const chunker = new UnreliableUnorderedChunker(42, message, chunkSize);
+                for (let i = 0; i < test.iterations; ++i) {
+                    const chunker = new UnreliableUnorderedChunker(42, test.message, test.chunkLength);
                     for (const _ of chunker) {}
                 }
 
@@ -125,17 +335,16 @@ describe('Chunker performance', () => {
 });
 
 describe('Unchunker performance', () => {
-    describe('reliable/ordered', () => {
+    describe('reliable/ordered (with reused buffer)', () => {
         for (const test of tests) {
-            const [iterations, messageSize, chunkSize, data] = test;
-            const chunks = data[1]; // reliable/ordered
-            const description = `${chunks.length} x ~${chunkSize / 1024} KiB chunks into ` +
-                `${iterations} x ${messageSize / 1048576} MiB messages`;
+            const chunks = test.reliableOrderedChunks;
+            const description = `${chunks.length} x ~${test.chunkLength / 1024} KiB chunks into ` +
+                `${test.iterations} x ${test.messageLength / 1048576} MiB messages`;
             it(description, (done) => {
-                const unchunker = new ReliableOrderedUnchunker();
+                const unchunker = new ReliableOrderedUnchunker(new ArrayBuffer(test.chunkLength));
                 let reassembledCount = 0;
                 unchunker.onMessage = () => {
-                    if (++reassembledCount === iterations) {
+                    if (++reassembledCount === test.iterations) {
                         const end = performance.now();
                         console.info(description, `Took ${(end - start) / 1000} seconds`);
                         expect(0).toBe(0);
@@ -145,7 +354,35 @@ describe('Unchunker performance', () => {
 
                 const start = performance.now();
 
-                for (let i = 0; i < iterations; ++i) {
+                for (let i = 0; i < test.iterations; ++i) {
+                    for (const chunk of chunks) {
+                        unchunker.add(chunk);
+                    }
+                }
+            });
+        }
+    });
+
+    describe('reliable/ordered (without reused buffer)', () => {
+        for (const test of tests) {
+            const chunks = test.reliableOrderedChunks;
+            const description = `${chunks.length} x ~${test.chunkLength / 1024} KiB chunks into ` +
+                `${test.iterations} x ${test.messageLength / 1048576} MiB messages`;
+            it(description, (done) => {
+                const unchunker = new ReliableOrderedUnchunker();
+                let reassembledCount = 0;
+                unchunker.onMessage = () => {
+                    if (++reassembledCount === test.iterations) {
+                        const end = performance.now();
+                        console.info(description, `Took ${(end - start) / 1000} seconds`);
+                        expect(0).toBe(0);
+                        done();
+                    }
+                };
+
+                const start = performance.now();
+
+                for (let i = 0; i < test.iterations; ++i) {
                     for (const chunk of chunks) {
                         unchunker.add(chunk);
                     }
@@ -156,15 +393,14 @@ describe('Unchunker performance', () => {
 
     describe('unreliable/unordered (with ordered chunks)', () => {
         for (const test of tests) {
-            const [iterations, messageSize, chunkSize, data] = test;
-            const chunks = data[2];  // unreliable/unordered (chunks are ordered)
-            const description = `${chunks.length} x ~${chunkSize / 1024} KiB chunks into ` +
-                `${iterations} x ${messageSize / 1048576} MiB messages`;
+            const chunks = test.unreliableUnorderedChunks;  // unreliable/unordered (chunks are ordered)
+            const description = `${chunks.length} x ~${test.chunkLength / 1024} KiB chunks into ` +
+                `${test.iterations} x ${test.messageLength / 1048576} MiB messages`;
             it(description, (done) => {
                 const unchunker = new UnreliableUnorderedUnchunker();
                 let reassembledCount = 0;
                 unchunker.onMessage = () => {
-                    if (++reassembledCount === iterations) {
+                    if (++reassembledCount === test.iterations) {
                         const end = performance.now();
                         console.info(description, `Took ${(end - start) / 1000} seconds`);
                         expect(0).toBe(0);
@@ -174,7 +410,7 @@ describe('Unchunker performance', () => {
 
                 const start = performance.now();
 
-                for (let i = 0; i < iterations; ++i) {
+                for (let i = 0; i < test.iterations; ++i) {
                     for (const chunk of chunks) {
                         unchunker.add(chunk);
                     }
@@ -185,15 +421,15 @@ describe('Unchunker performance', () => {
 
     describe('unreliable/unordered (with unordered chunks)', () => {
         for (const test of tests) {
-            const [iterations, messageSize, chunkSize, data] = test;
-            const chunks = data[3];  // unreliable/unordered (chunks are deterministically shuffled)
-            const description = `${chunks.length} x ~${chunkSize / 1024} KiB chunks into ` +
-                `${iterations} x ${messageSize / 1048576} MiB messages`;
+            // unreliable/unordered (chunks are deterministically shuffled)
+            const chunks = test.shuffledUnreliableUnorderedChunks;
+            const description = `${chunks.length} x ~${test.chunkLength / 1024} KiB chunks into ` +
+                `${test.iterations} x ${test.messageLength / 1048576} MiB messages`;
             it(description, (done) => {
                 const unchunker = new UnreliableUnorderedUnchunker();
                 let reassembledCount = 0;
                 unchunker.onMessage = () => {
-                    if (++reassembledCount === iterations) {
+                    if (++reassembledCount === test.iterations) {
                         const end = performance.now();
                         console.info(description, `Took ${(end - start) / 1000} seconds`);
                         expect(0).toBe(0);
@@ -203,7 +439,7 @@ describe('Unchunker performance', () => {
 
                 const start = performance.now();
 
-                for (let i = 0; i < iterations; ++i) {
+                for (let i = 0; i < test.iterations; ++i) {
                     for (const chunk of chunks) {
                         unchunker.add(chunk);
                     }

--- a/tests/test_chunk.spec.ts
+++ b/tests/test_chunk.spec.ts
@@ -1,47 +1,104 @@
 /// <reference path="jasmine.d.ts" />
 
-import {Chunk} from "../src/unchunker";
+import { Mode, RELIABLE_ORDERED_HEADER_LENGTH, UNRELIABLE_UNORDERED_HEADER_LENGTH } from '../src/main';
+import { Chunk } from '../src/unchunker';
 
 export default () => { describe('Chunk', function() {
+    describe('reliable/ordered', () => {
+        it('parses valid data', () => {
+            const data = Uint8Array.of(
+                // Options
+                6,
+                // Data
+                1, 2, 3, 4, 5, 6
+            );
+            const chunk = new Chunk(data, Mode.ReliableOrdered, RELIABLE_ORDERED_HEADER_LENGTH);
+            expect(chunk.endOfMessage).toBe(false);
+            expect(chunk.payload).toEqual(Uint8Array.of(1, 2, 3, 4, 5, 6));
+        });
 
-    it('parses valid data', () => {
-        const arr = Uint8Array.of(
-            // Options
-            0,
-            // Id
-            0xff, 0xff, 0xff, 0xfe,
-            // Serial
-            0, 0, 0, 1,
-            // Data
-            1, 2, 3, 4, 5, 6
-        );
-        const chunk = new Chunk(arr.buffer);
-        expect(chunk.isEndOfMessage).toBe(false);
-        expect(chunk.id).toEqual(4294967294);
-        expect(chunk.serial).toEqual(1);
-        expect(chunk.data).toEqual(Uint8Array.of(1, 2, 3, 4, 5, 6));
+        it('parses empty data', () => {
+            const data = Uint8Array.of(
+                // Options
+                7,
+            );
+            const chunk = new Chunk(data, Mode.ReliableOrdered, RELIABLE_ORDERED_HEADER_LENGTH);
+            expect(chunk.endOfMessage).toBe(true);
+            expect(chunk.payload).toEqual(new Uint8Array(0));
+        });
+
+        it('rejects invalid chunks', () => {
+            const data = new Uint8Array(0);
+            const parse = () => new Chunk(data, Mode.ReliableOrdered, RELIABLE_ORDERED_HEADER_LENGTH);
+            expect(parse).toThrowError('Invalid chunk: Too short');
+        });
+
+        it('rejects invalid mode', () => {
+            const data = Uint8Array.of(
+                // Options
+                0,
+                // Id
+                0xff, 0xff, 0xff, 0xfe,
+                // Serial
+                0, 0, 0, 1,
+                // Data
+                1, 2, 3, 4, 5, 6
+            );
+            const parse = () => new Chunk(data, Mode.ReliableOrdered, RELIABLE_ORDERED_HEADER_LENGTH);
+            expect(parse).toThrowError('Invalid chunk: Unexpected mode 0');
+        });
     });
 
-    it('parses empty data', () => {
-        const arr = Uint8Array.of(
-            // Options
-            1,
-            // Id
-            0, 0, 2, 0,
-            // Serial
-            0, 0, 0, 1
-        );
-        const chunk = new Chunk(arr.buffer);
-        expect(chunk.isEndOfMessage).toBe(true);
-        expect(chunk.id).toEqual(512);
-        expect(chunk.serial).toEqual(1);
-        expect(chunk.data).toEqual(new Uint8Array(0));
-    });
+    describe('unreliable/unordered', () => {
+        it('parses valid data', () => {
+            const data = Uint8Array.of(
+                // Options
+                0,
+                // Id
+                0xff, 0xff, 0xff, 0xfe,
+                // Serial
+                0, 0, 0, 1,
+                // Data
+                1, 2, 3, 4, 5, 6
+            );
+            const chunk = new Chunk(data, Mode.UnreliableUnordered, UNRELIABLE_UNORDERED_HEADER_LENGTH);
+            expect(chunk.endOfMessage).toBe(false);
+            expect(chunk.id).toEqual(4294967294);
+            expect(chunk.serial).toEqual(1);
+            expect(chunk.payload).toEqual(Uint8Array.of(1, 2, 3, 4, 5, 6));
+        });
 
-    it('rejects invalid chunks', () => {
-        const arr = Uint8Array.of(1, 2, 3);
-        const parse = () => new Chunk(arr.buffer);
-        expect(parse).toThrowError("Invalid chunk: Too short");
-    });
+        it('parses empty data', () => {
+            const data = Uint8Array.of(
+                // Options
+                1,
+                // Id
+                0, 0, 2, 0,
+                // Serial
+                0, 0, 0, 1
+            );
+            const chunk = new Chunk(data, Mode.UnreliableUnordered, UNRELIABLE_UNORDERED_HEADER_LENGTH);
+            expect(chunk.endOfMessage).toBe(true);
+            expect(chunk.id).toEqual(512);
+            expect(chunk.serial).toEqual(1);
+            expect(chunk.payload).toEqual(new Uint8Array(0));
+        });
 
+        it('rejects invalid chunks', () => {
+            const data = Uint8Array.of(1, 2, 3);
+            const parse = () => new Chunk(data, Mode.UnreliableUnordered, UNRELIABLE_UNORDERED_HEADER_LENGTH);
+            expect(parse).toThrowError('Invalid chunk: Too short');
+        });
+
+        it('rejects invalid mode', () => {
+            const data = Uint8Array.of(
+                // Options
+                6,
+                // Data
+                1, 2, 3, 4, 5, 6, 7, 8, 9
+            );
+            const parse = () => new Chunk(data, Mode.UnreliableUnordered, UNRELIABLE_UNORDERED_HEADER_LENGTH);
+            expect(parse).toThrowError('Invalid chunk: Unexpected mode 6');
+        });
+    });
 })};

--- a/tests/test_chunker.spec.ts
+++ b/tests/test_chunker.spec.ts
@@ -1,94 +1,205 @@
 /// <reference path="jasmine.d.ts" />
 
-import { UNRELIABLE_UNORDERED_HEADER_LENGTH, UnreliableUnorderedChunker } from '../src/main';
+import {
+    RELIABLE_ORDERED_HEADER_LENGTH,
+    UNRELIABLE_UNORDERED_HEADER_LENGTH,
+    ReliableOrderedChunker,
+    UnreliableUnorderedChunker,
+} from '../src/main';
 
 export default () => { describe('UnreliableUnorderedChunker', function() {
-    const MORE = 0;
-    const END = 1;
-    const ID = 42;
+    const tests: Array<ArrayBuffer | undefined> = [new ArrayBuffer(128), undefined];
 
-    // TODO: all below with buffer in chunker
+    for (const buffer of tests) {
+        const hasBufferStr = buffer !== undefined ? 'yes' : 'no';
 
-    it('chunkifies multiples of the chunk size', () => {
-        const message = Uint8Array.of(1, 2, 3, 4, 5, 6);
-        const chunker = new UnreliableUnorderedChunker(ID, message, UNRELIABLE_UNORDERED_HEADER_LENGTH + 2);
-        expect(chunker.hasNext).toBe(true);
-        expect(chunker.next().value)
-            .toEqual(Uint8Array.of(MORE, /*Id*/0,0,0,ID, /*Serial*/0,0,0,0, /*Data*/1,2));
-        expect(chunker.hasNext).toBe(true);
-        expect(chunker.next().value)
-            .toEqual(Uint8Array.of(MORE, /*Id*/0,0,0,ID, /*Serial*/0,0,0,1, /*Data*/3,4));
-        expect(chunker.hasNext).toBe(true);
-        expect(chunker.next().value)
-            .toEqual(Uint8Array.of(END, /*Id*/0,0,0,ID, /*Serial*/0,0,0,2, /*Data*/5,6));
-        expect(chunker.hasNext).toBe(false);
-        expect(chunker.next().done).toBe(true);
-    });
+        describe(`ReliableOrderedChunker (buffer=${hasBufferStr})`, () => {
+            const MORE = 6;
+            const END = 7;
 
-    it('chunkifies non-multiples of the chunk size', () => {
-        const message = Uint8Array.of(1, 2, 3, 4, 5, 6);
-        const chunker = new UnreliableUnorderedChunker(ID, message, UNRELIABLE_UNORDERED_HEADER_LENGTH + 4);
-        expect(chunker.next().value)
-            .toEqual(Uint8Array.of(MORE, /*Id*/0,0,0,ID, /*Serial*/0,0,0,0, /*Data*/1,2,3,4));
-        expect(chunker.next().value)
-            .toEqual(Uint8Array.of(END, /*Id*/0,0,0,ID, /*Serial*/0,0,0,1, /*Data*/5,6));
-        expect(chunker.next().done).toBe(true);
-    });
+            it('chunkifies multiples of the chunk size', () => {
+                const message = Uint8Array.of(1, 2, 3, 4, 5, 6);
+                const chunker = new ReliableOrderedChunker(message, RELIABLE_ORDERED_HEADER_LENGTH + 2, buffer);
+                expect(chunker.hasNext).toBe(true);
+                expect(chunker.next().value)
+                    .toEqual(Uint8Array.of(MORE, /*Data*/1, 2));
+                expect(chunker.hasNext).toBe(true);
+                expect(chunker.next().value)
+                    .toEqual(Uint8Array.of(MORE, /*Data*/3, 4));
+                expect(chunker.hasNext).toBe(true);
+                expect(chunker.next().value)
+                    .toEqual(Uint8Array.of(END, /*Data*/5, 6));
+                expect(chunker.hasNext).toBe(false);
+                expect(chunker.next().done).toBe(true);
+            });
 
-    it('chunkifies data smaller than chunk size', () => {
-        const message = Uint8Array.of(1, 2);
-        const chunker = new UnreliableUnorderedChunker(ID, message, UNRELIABLE_UNORDERED_HEADER_LENGTH + 99);
-        expect(chunker.next().value)
-            .toEqual(Uint8Array.of(END, /*Id*/0,0,0,ID, /*Serial*/0,0,0,0, /*Data*/1,2));
-        expect(chunker.next().done).toBe(true);
-    });
+            it('chunkifies non-multiples of the chunk size', () => {
+                const message = Uint8Array.of(1, 2, 3, 4, 5, 6);
+                const chunker = new ReliableOrderedChunker(message, RELIABLE_ORDERED_HEADER_LENGTH + 4, buffer);
+                expect(chunker.next().value)
+                    .toEqual(Uint8Array.of(MORE, /*Data*/1, 2, 3, 4));
+                expect(chunker.next().value)
+                    .toEqual(Uint8Array.of(END, /*Data*/5, 6));
+                expect(chunker.next().done).toBe(true);
+            });
 
-    it('allows chunk size of 10', () => {
-        const message = Uint8Array.of(1, 2);
-        const chunker = new UnreliableUnorderedChunker(ID, message, UNRELIABLE_UNORDERED_HEADER_LENGTH + 1);
-        expect(chunker.next().value)
-            .toEqual(Uint8Array.of(MORE, /*Id*/0,0,0,ID, /*Serial*/0,0,0,0, /*Data*/1));
-        expect(chunker.next().value)
-            .toEqual(Uint8Array.of(END, /*Id*/0,0,0,ID, /*Serial*/0,0,0,1, /*Data*/2));
-        expect(chunker.next().done).toBe(true);
-    });
+            it('chunkifies data smaller than chunk size', () => {
+                const message = Uint8Array.of(1, 2);
+                const chunker = new ReliableOrderedChunker(message, RELIABLE_ORDERED_HEADER_LENGTH + 99, buffer);
+                expect(chunker.next().value)
+                    .toEqual(Uint8Array.of(END, /*Data*/1, 2));
+                expect(chunker.next().done).toBe(true);
+            });
 
-    it('does not allow chunk size of 0', () => {
-        const message = Uint8Array.of(1, 2);
-        expect(() => new UnreliableUnorderedChunker(ID, message, 0)).toThrowError('Chunk size must be at least 10');
-    });
+            it('allows chunk size of 2', () => {
+                const message = Uint8Array.of(1, 2);
+                const chunker = new ReliableOrderedChunker(message, RELIABLE_ORDERED_HEADER_LENGTH + 1, buffer);
+                expect(chunker.next().value)
+                    .toEqual(Uint8Array.of(MORE, /*Data*/1));
+                expect(chunker.next().value)
+                    .toEqual(Uint8Array.of(END, /*Data*/2));
+                expect(chunker.next().done).toBe(true);
+            });
 
-    it('does not allow chunk size of only the header length', () => {
-        const message = Uint8Array.of(1, 2);
-        expect(() => new UnreliableUnorderedChunker(ID, message, UNRELIABLE_UNORDERED_HEADER_LENGTH)).toThrowError('Chunk size must be at least 10');
-    });
+            it('does not allow chunk size of 0', () => {
+                const message = Uint8Array.of(1, 2);
+                expect(() => new ReliableOrderedChunker(message, 0, buffer))
+                    .toThrowError('Chunk size must be at least 2');
+            });
 
-    it('does not allow negative chunk size', () => {
-        const message = Uint8Array.of(1, 2);
-        expect(() => new UnreliableUnorderedChunker(ID, message, -2)).toThrowError('Chunk size must be at least 10');
-    });
+            it('does not allow chunk size of only the header length', () => {
+                const message = Uint8Array.of(1, 2);
+                expect(() => new ReliableOrderedChunker(message, RELIABLE_ORDERED_HEADER_LENGTH, buffer))
+                    .toThrowError('Chunk size must be at least 2');
+            });
 
-    it('does not allow chunking of empty arrays', () => {
-        const message = new Uint8Array(0);
-        expect(() => new UnreliableUnorderedChunker(ID, message, UNRELIABLE_UNORDERED_HEADER_LENGTH + 2)).toThrowError('Message may not be empty');
-    });
+            it('does not allow negative chunk size', () => {
+                const message = Uint8Array.of(1, 2);
+                expect(() => new ReliableOrderedChunker(message, -2, buffer))
+                    .toThrowError('Chunk size must be at least 2');
+            });
 
-    it('does not allow out-of-bounds id', () => {
-        const message = Uint8Array.of(1, 2);
-        expect(() => new UnreliableUnorderedChunker(2**32, message, UNRELIABLE_UNORDERED_HEADER_LENGTH + 2)).toThrowError('Message id must be between 0 and 2**32-1');
-        expect(() => new UnreliableUnorderedChunker(-1, message, UNRELIABLE_UNORDERED_HEADER_LENGTH + 2)).toThrowError('Message id must be between 0 and 2**32-1');
-    });
+            it('does not allow chunking of empty arrays', () => {
+                const message = new Uint8Array(0);
+                expect(() => new ReliableOrderedChunker(message, RELIABLE_ORDERED_HEADER_LENGTH + 2, buffer))
+                    .toThrowError('Message may not be empty');
+            });
 
-    it('can be iterated using the iterable protocol', () => {
-        const message = Uint8Array.of(1, 2, 3, 4, 5, 6);
-        const chunker = new UnreliableUnorderedChunker(ID, message, UNRELIABLE_UNORDERED_HEADER_LENGTH + 2);
-        const chunks = [];
-        for (let chunk of chunker) {
-            chunks.push(chunk);
-        }
-        expect(chunks.length).toEqual(3);
-        expect(chunks[0]).toEqual(Uint8Array.of(MORE, /*Id*/0,0,0,ID, /*Serial*/0,0,0,0, /*Data*/1,2));
-        expect(chunks[1]).toEqual(Uint8Array.of(MORE, /*Id*/0,0,0,ID, /*Serial*/0,0,0,1, /*Data*/3,4));
-        expect(chunks[2]).toEqual(Uint8Array.of(END, /*Id*/0,0,0,ID, /*Serial*/0,0,0,2, /*Data*/5,6));
-    });
+            it('can be iterated using the iterable protocol', () => {
+                const message = Uint8Array.of(1, 2, 3, 4, 5, 6);
+                const chunker = new ReliableOrderedChunker(message, RELIABLE_ORDERED_HEADER_LENGTH + 2, buffer);
+                const chunks = [];
+                for (let chunk of chunker) {
+                    chunks.push(chunk.slice());
+                }
+                expect(chunks.length).toEqual(3);
+                expect(chunks[0]).toEqual(Uint8Array.of(MORE, /*Data*/1, 2));
+                expect(chunks[1]).toEqual(Uint8Array.of(MORE, /*Data*/3, 4));
+                expect(chunks[2]).toEqual(Uint8Array.of(END, /*Data*/5, 6));
+            });
+        });
+
+        describe(`UnreliableUnorderedChunker (buffer=${hasBufferStr})`, () => {
+            const MORE = 0;
+            const END = 1;
+            const ID = 42;
+
+            it('chunkifies multiples of the chunk size', () => {
+                const message = Uint8Array.of(1, 2, 3, 4, 5, 6);
+                const chunker = new UnreliableUnorderedChunker(
+                    ID, message, UNRELIABLE_UNORDERED_HEADER_LENGTH + 2, buffer);
+                expect(chunker.hasNext).toBe(true);
+                expect(chunker.next().value)
+                    .toEqual(Uint8Array.of(MORE, /*Id*/0, 0, 0, ID, /*Serial*/0, 0, 0, 0, /*Data*/1, 2));
+                expect(chunker.hasNext).toBe(true);
+                expect(chunker.next().value)
+                    .toEqual(Uint8Array.of(MORE, /*Id*/0, 0, 0, ID, /*Serial*/0, 0, 0, 1, /*Data*/3, 4));
+                expect(chunker.hasNext).toBe(true);
+                expect(chunker.next().value)
+                    .toEqual(Uint8Array.of(END, /*Id*/0, 0, 0, ID, /*Serial*/0, 0, 0, 2, /*Data*/5, 6));
+                expect(chunker.hasNext).toBe(false);
+                expect(chunker.next().done).toBe(true);
+            });
+
+            it('chunkifies non-multiples of the chunk size', () => {
+                const message = Uint8Array.of(1, 2, 3, 4, 5, 6);
+                const chunker = new UnreliableUnorderedChunker(
+                    ID, message, UNRELIABLE_UNORDERED_HEADER_LENGTH + 4, buffer);
+                expect(chunker.next().value)
+                    .toEqual(Uint8Array.of(MORE, /*Id*/0, 0, 0, ID, /*Serial*/0, 0, 0, 0, /*Data*/1, 2, 3, 4));
+                expect(chunker.next().value)
+                    .toEqual(Uint8Array.of(END, /*Id*/0, 0, 0, ID, /*Serial*/0, 0, 0, 1, /*Data*/5, 6));
+                expect(chunker.next().done).toBe(true);
+            });
+
+            it('chunkifies data smaller than chunk size', () => {
+                const message = Uint8Array.of(1, 2);
+                const chunker = new UnreliableUnorderedChunker(
+                    ID, message, UNRELIABLE_UNORDERED_HEADER_LENGTH + 99, buffer);
+                expect(chunker.next().value)
+                    .toEqual(Uint8Array.of(END, /*Id*/0, 0, 0, ID, /*Serial*/0, 0, 0, 0, /*Data*/1, 2));
+                expect(chunker.next().done).toBe(true);
+            });
+
+            it('allows chunk size of 10', () => {
+                const message = Uint8Array.of(1, 2);
+                const chunker = new UnreliableUnorderedChunker(
+                    ID, message, UNRELIABLE_UNORDERED_HEADER_LENGTH + 1, buffer);
+                expect(chunker.next().value)
+                    .toEqual(Uint8Array.of(MORE, /*Id*/0, 0, 0, ID, /*Serial*/0, 0, 0, 0, /*Data*/1));
+                expect(chunker.next().value)
+                    .toEqual(Uint8Array.of(END, /*Id*/0, 0, 0, ID, /*Serial*/0, 0, 0, 1, /*Data*/2));
+                expect(chunker.next().done).toBe(true);
+            });
+
+            it('does not allow chunk size of 0', () => {
+                const message = Uint8Array.of(1, 2);
+                expect(() => new UnreliableUnorderedChunker(ID, message, 0, buffer))
+                    .toThrowError('Chunk size must be at least 10');
+            });
+
+            it('does not allow chunk size of only the header length', () => {
+                const message = Uint8Array.of(1, 2);
+                expect(() => new UnreliableUnorderedChunker(ID, message, UNRELIABLE_UNORDERED_HEADER_LENGTH, buffer))
+                    .toThrowError('Chunk size must be at least 10');
+            });
+
+            it('does not allow negative chunk size', () => {
+                const message = Uint8Array.of(1, 2);
+                expect(() => new UnreliableUnorderedChunker(ID, message, -2, buffer))
+                    .toThrowError('Chunk size must be at least 10');
+            });
+
+            it('does not allow chunking of empty arrays', () => {
+                const message = new Uint8Array(0);
+                expect(() => new UnreliableUnorderedChunker(
+                    ID, message, UNRELIABLE_UNORDERED_HEADER_LENGTH + 2, buffer))
+                    .toThrowError('Message may not be empty');
+            });
+
+            it('does not allow out-of-bounds id', () => {
+                const message = Uint8Array.of(1, 2);
+                expect(() => new UnreliableUnorderedChunker(
+                    2 ** 32, message, UNRELIABLE_UNORDERED_HEADER_LENGTH + 2, buffer))
+                    .toThrowError('Message id must be between 0 and 2**32-1');
+                expect(() => new UnreliableUnorderedChunker(
+                    -1, message, UNRELIABLE_UNORDERED_HEADER_LENGTH + 2, buffer))
+                    .toThrowError('Message id must be between 0 and 2**32-1');
+            });
+
+            it('can be iterated using the iterable protocol', () => {
+                const message = Uint8Array.of(1, 2, 3, 4, 5, 6);
+                const chunker = new UnreliableUnorderedChunker(
+                    ID, message, UNRELIABLE_UNORDERED_HEADER_LENGTH + 2, buffer);
+                const chunks = [];
+                for (let chunk of chunker) {
+                    chunks.push(chunk.slice());
+                }
+                expect(chunks.length).toEqual(3);
+                expect(chunks[0]).toEqual(Uint8Array.of(MORE, /*Id*/0, 0, 0, ID, /*Serial*/0, 0, 0, 0, /*Data*/1, 2));
+                expect(chunks[1]).toEqual(Uint8Array.of(MORE, /*Id*/0, 0, 0, ID, /*Serial*/0, 0, 0, 1, /*Data*/3, 4));
+                expect(chunks[2]).toEqual(Uint8Array.of(END, /*Id*/0, 0, 0, ID, /*Serial*/0, 0, 0, 2, /*Data*/5, 6));
+            });
+        });
+    }
 })};

--- a/tests/test_chunker.spec.ts
+++ b/tests/test_chunker.spec.ts
@@ -1,18 +1,17 @@
 /// <reference path="jasmine.d.ts" />
 
-import {Chunker} from "../src/main";
-import {Common} from "../src/common";
+import { UNRELIABLE_UNORDERED_HEADER_LENGTH, UnreliableUnorderedChunker } from '../src/main';
 
-export default () => { describe('Chunker', function() {
-
+export default () => { describe('UnreliableUnorderedChunker', function() {
     const MORE = 0;
     const END = 1;
-
     const ID = 42;
 
+    // TODO: all below with buffer in chunker
+
     it('chunkifies multiples of the chunk size', () => {
-        const arr = Uint8Array.of(1, 2, 3, 4, 5, 6);
-        const chunker = new Chunker(ID, arr, Common.HEADER_LENGTH + 2);
+        const message = Uint8Array.of(1, 2, 3, 4, 5, 6);
+        const chunker = new UnreliableUnorderedChunker(ID, message, UNRELIABLE_UNORDERED_HEADER_LENGTH + 2);
         expect(chunker.hasNext).toBe(true);
         expect(chunker.next().value)
             .toEqual(Uint8Array.of(MORE, /*Id*/0,0,0,ID, /*Serial*/0,0,0,0, /*Data*/1,2));
@@ -27,8 +26,8 @@ export default () => { describe('Chunker', function() {
     });
 
     it('chunkifies non-multiples of the chunk size', () => {
-        const arr = Uint8Array.of(1, 2, 3, 4, 5, 6);
-        const chunker = new Chunker(ID, arr, Common.HEADER_LENGTH + 4);
+        const message = Uint8Array.of(1, 2, 3, 4, 5, 6);
+        const chunker = new UnreliableUnorderedChunker(ID, message, UNRELIABLE_UNORDERED_HEADER_LENGTH + 4);
         expect(chunker.next().value)
             .toEqual(Uint8Array.of(MORE, /*Id*/0,0,0,ID, /*Serial*/0,0,0,0, /*Data*/1,2,3,4));
         expect(chunker.next().value)
@@ -37,16 +36,16 @@ export default () => { describe('Chunker', function() {
     });
 
     it('chunkifies data smaller than chunk size', () => {
-        const arr = Uint8Array.of(1, 2);
-        const chunker = new Chunker(ID, arr, Common.HEADER_LENGTH + 99);
+        const message = Uint8Array.of(1, 2);
+        const chunker = new UnreliableUnorderedChunker(ID, message, UNRELIABLE_UNORDERED_HEADER_LENGTH + 99);
         expect(chunker.next().value)
             .toEqual(Uint8Array.of(END, /*Id*/0,0,0,ID, /*Serial*/0,0,0,0, /*Data*/1,2));
         expect(chunker.next().done).toBe(true);
     });
 
     it('allows chunk size of 10', () => {
-        const arr = Uint8Array.of(1, 2);
-        const chunker = new Chunker(ID, arr, Common.HEADER_LENGTH + 1);
+        const message = Uint8Array.of(1, 2);
+        const chunker = new UnreliableUnorderedChunker(ID, message, UNRELIABLE_UNORDERED_HEADER_LENGTH + 1);
         expect(chunker.next().value)
             .toEqual(Uint8Array.of(MORE, /*Id*/0,0,0,ID, /*Serial*/0,0,0,0, /*Data*/1));
         expect(chunker.next().value)
@@ -55,34 +54,34 @@ export default () => { describe('Chunker', function() {
     });
 
     it('does not allow chunk size of 0', () => {
-        const arr = Uint8Array.of(1, 2);
-        expect(() => new Chunker(ID, arr, 0)).toThrowError("Chunk size must be at least 10");
+        const message = Uint8Array.of(1, 2);
+        expect(() => new UnreliableUnorderedChunker(ID, message, 0)).toThrowError('Chunk size must be at least 10');
     });
 
     it('does not allow chunk size of only the header length', () => {
-        const arr = Uint8Array.of(1, 2);
-        expect(() => new Chunker(ID, arr, Common.HEADER_LENGTH)).toThrowError("Chunk size must be at least 10");
+        const message = Uint8Array.of(1, 2);
+        expect(() => new UnreliableUnorderedChunker(ID, message, UNRELIABLE_UNORDERED_HEADER_LENGTH)).toThrowError('Chunk size must be at least 10');
     });
 
     it('does not allow negative chunk size', () => {
-        const arr = Uint8Array.of(1, 2);
-        expect(() => new Chunker(ID, arr, -2)).toThrowError("Chunk size must be at least 10");
+        const message = Uint8Array.of(1, 2);
+        expect(() => new UnreliableUnorderedChunker(ID, message, -2)).toThrowError('Chunk size must be at least 10');
     });
 
     it('does not allow chunking of empty arrays', () => {
-        const arr = new Uint8Array(0);
-        expect(() => new Chunker(ID, arr, Common.HEADER_LENGTH + 2)).toThrowError("Array may not be empty");
+        const message = new Uint8Array(0);
+        expect(() => new UnreliableUnorderedChunker(ID, message, UNRELIABLE_UNORDERED_HEADER_LENGTH + 2)).toThrowError('Message may not be empty');
     });
 
     it('does not allow out-of-bounds id', () => {
-        const arr = Uint8Array.of(1, 2);
-        expect(() => new Chunker(2**32, arr, Common.HEADER_LENGTH + 2)).toThrowError("Message id must be between 0 and 2**32-1");
-        expect(() => new Chunker(-1, arr, Common.HEADER_LENGTH + 2)).toThrowError("Message id must be between 0 and 2**32-1");
+        const message = Uint8Array.of(1, 2);
+        expect(() => new UnreliableUnorderedChunker(2**32, message, UNRELIABLE_UNORDERED_HEADER_LENGTH + 2)).toThrowError('Message id must be between 0 and 2**32-1');
+        expect(() => new UnreliableUnorderedChunker(-1, message, UNRELIABLE_UNORDERED_HEADER_LENGTH + 2)).toThrowError('Message id must be between 0 and 2**32-1');
     });
 
     it('can be iterated using the iterable protocol', () => {
-        const arr = Uint8Array.of(1, 2, 3, 4, 5, 6);
-        const chunker = new Chunker(ID, arr, Common.HEADER_LENGTH + 2);
+        const message = Uint8Array.of(1, 2, 3, 4, 5, 6);
+        const chunker = new UnreliableUnorderedChunker(ID, message, UNRELIABLE_UNORDERED_HEADER_LENGTH + 2);
         const chunks = [];
         for (let chunk of chunker) {
             chunks.push(chunk);
@@ -92,5 +91,4 @@ export default () => { describe('Chunker', function() {
         expect(chunks[1]).toEqual(Uint8Array.of(MORE, /*Id*/0,0,0,ID, /*Serial*/0,0,0,1, /*Data*/3,4));
         expect(chunks[2]).toEqual(Uint8Array.of(END, /*Id*/0,0,0,ID, /*Serial*/0,0,0,2, /*Data*/5,6));
     });
-
 })};

--- a/tests/test_common.spec.ts
+++ b/tests/test_common.spec.ts
@@ -1,6 +1,6 @@
 /// <reference path="jasmine.d.ts" />
 
-import { MODE_BITFIELD } from '../src/common';
+import { MODE_BITMASK } from '../src/common';
 import { RELIABLE_ORDERED_HEADER_LENGTH, UNRELIABLE_UNORDERED_HEADER_LENGTH, Mode } from '../src/main';
 
 export default () => { describe('Common', function() {
@@ -18,7 +18,7 @@ export default () => { describe('Common', function() {
     });
 
     it('modes are detected as defined by the spec', () => {
-        expect(255 & MODE_BITFIELD).toEqual(Mode.ReliableOrdered);
-        expect(249 & MODE_BITFIELD).toEqual(Mode.UnreliableUnordered);
+        expect(255 & MODE_BITMASK).toEqual(Mode.ReliableOrdered);
+        expect(249 & MODE_BITMASK).toEqual(Mode.UnreliableUnordered);
     });
 })};

--- a/tests/test_common.spec.ts
+++ b/tests/test_common.spec.ts
@@ -1,11 +1,24 @@
 /// <reference path="jasmine.d.ts" />
 
-import { HEADER_LENGTH } from '../src/main';
+import { MODE_BITFIELD } from '../src/common';
+import { RELIABLE_ORDERED_HEADER_LENGTH, UNRELIABLE_UNORDERED_HEADER_LENGTH, Mode } from '../src/main';
 
 export default () => { describe('Common', function() {
-
-    it('exposes HEADER_LENGTH', () => {
-        expect(HEADER_LENGTH).toEqual(9);
+    it('exposes RELIABLE_ORDERED_HEADER_LENGTH', () => {
+        expect(RELIABLE_ORDERED_HEADER_LENGTH).toEqual(1);
     });
 
+    it('exposes UNRELIABLE_UNORDERED_HEADER_LENGTH', () => {
+        expect(UNRELIABLE_UNORDERED_HEADER_LENGTH).toEqual(9);
+    });
+
+    it('exposes Mode', () => {
+        expect(Mode.ReliableOrdered).toEqual(6);
+        expect(Mode.UnreliableUnordered).toEqual(0);
+    });
+
+    it('modes are detected as defined by the spec', () => {
+        expect(255 & MODE_BITFIELD).toEqual(Mode.ReliableOrdered);
+        expect(249 & MODE_BITFIELD).toEqual(Mode.UnreliableUnordered);
+    });
 })};

--- a/tests/test_unchunker.spec.ts
+++ b/tests/test_unchunker.spec.ts
@@ -319,8 +319,8 @@ export default () => {
             });
 
             it('does not accept reserved mode', () => {
-                const unchunker = new ReliableOrderedUnchunker();
-                const add = () => unchunker.add(Uint8Array.of(2));
+                const unchunker = new UnreliableUnorderedUnchunker();
+                const add = () => unchunker.add(Uint8Array.of(2, 0, 0, 0, 0, 1, 1, 1, 1));
                 expect(add).toThrowError('Invalid chunk: Unexpected mode 2');
             });
         });

--- a/tests/test_unchunker.spec.ts
+++ b/tests/test_unchunker.spec.ts
@@ -1,7 +1,7 @@
 /// <reference path="jasmine.d.ts" />
 /// <reference path="../chunked-dc.d.ts" />
 
-import {UnreliableUnorderedUnchunker} from '../src/main';
+import { ReliableOrderedUnchunker, UnreliableUnorderedUnchunker } from '../src/main';
 
 /**
  * A wrapper around an unchunker that stores finished messages in a list.
@@ -10,7 +10,7 @@ class LoggingUnchunker {
     public messages: Uint8Array[] = [];
     constructor(unchunker: chunkedDc.Unchunker) {
         unchunker.onMessage = (message: Uint8Array) => {
-            this.messages.push(message);
+            this.messages.push(message.slice());
         }
     }
 }
@@ -38,198 +38,332 @@ function shuffle(array) {
     return array;
 }
 
-export default () => { describe('UnreliableUnorderedUnchunker', function() {
-    const MORE = 0;
-    const END = 1;
-    const ID = 42;
+export default () => {
+    describe('ReliableOrderedUnchunker', function() {
+        const MORE = 6;
+        const END = 7;
 
-    describe('base', () => {
-        it('unchunkifies regular messages', () => {
-            const unchunker = new UnreliableUnorderedUnchunker();
-            const logger = new LoggingUnchunker(unchunker);
+        const tests: Array<ArrayBuffer | undefined> = [new ArrayBuffer(128), undefined];
 
-            expect(logger.messages.length).toEqual(0);
+        for (const buffer of tests) {
+            const hasBufferStr = buffer !== undefined ? 'yes' : 'no';
 
-            unchunker.add(Uint8Array.of(MORE, 0, 0, 0, ID, 0, 0, 0, 0, 1, 2, 3));
-            unchunker.add(Uint8Array.of(MORE, 0, 0, 0, ID, 0, 0, 0, 1, 4, 5, 6));
-            unchunker.add(Uint8Array.of(END, 0, 0, 0, ID, 0, 0, 0, 2, 7, 8));
+            describe(`base (buffer=${hasBufferStr})`, () => {
+                it('unchunkifies regular messages', () => {
+                    const unchunker = new ReliableOrderedUnchunker(buffer);
+                    const logger = new LoggingUnchunker(unchunker);
 
-            expect(logger.messages.length).toEqual(1);
-            expect(logger.messages[0]).toEqual(Uint8Array.of(1, 2, 3, 4, 5, 6, 7, 8));
-        });
+                    expect(logger.messages.length).toEqual(0);
 
-        it('unchunkifies single-chunk messages', () => {
-            const unchunker = new UnreliableUnorderedUnchunker();
-            const logger = new LoggingUnchunker(unchunker);
+                    unchunker.add(Uint8Array.of(MORE, 1, 2, 3));
+                    unchunker.add(Uint8Array.of(MORE, 4, 5, 6));
+                    unchunker.add(Uint8Array.of(END, 7, 8));
 
-            expect(logger.messages.length).toEqual(0);
+                    expect(logger.messages.length).toEqual(1);
+                    expect(logger.messages[0]).toEqual(Uint8Array.of(1, 2, 3, 4, 5, 6, 7, 8));
+                });
 
-            unchunker.add(Uint8Array.of(END, 0, 0, 0, ID, 0, 0, 0, 0, 7, 7, 7));
+                it('unchunkifies single-chunk messages', () => {
+                    const unchunker = new ReliableOrderedUnchunker(buffer);
+                    const logger = new LoggingUnchunker(unchunker);
 
-            expect(logger.messages.length).toEqual(1);
-            expect(logger.messages[0]).toEqual(Uint8Array.of(7, 7, 7));
-        });
+                    expect(logger.messages.length).toEqual(0);
 
-        it('unchunkifies empty chunk messages', () => {
-            const unchunker = new UnreliableUnorderedUnchunker();
-            const logger = new LoggingUnchunker(unchunker);
+                    unchunker.add(Uint8Array.of(END, 7, 7, 7));
 
-            expect(logger.messages.length).toEqual(0);
+                    expect(logger.messages.length).toEqual(1);
+                    expect(logger.messages[0]).toEqual(Uint8Array.of(7, 7, 7));
+                });
 
-            unchunker.add(Uint8Array.of(END, 0, 0, 0, ID, 0, 0, 0, 0));
+                it('unchunkifies empty chunk messages', () => {
+                    const unchunker = new ReliableOrderedUnchunker(buffer);
+                    const logger = new LoggingUnchunker(unchunker);
 
-            expect(logger.messages.length).toEqual(1);
-            expect(logger.messages[0]).toEqual(new Uint8Array(0));
-        });
+                    expect(logger.messages.length).toEqual(0);
 
-        it('unchunkifies multiple empty chunk messages', () => {
-            const unchunker = new UnreliableUnorderedUnchunker();
-            const logger = new LoggingUnchunker(unchunker);
+                    unchunker.add(Uint8Array.of(END));
 
-            expect(logger.messages.length).toEqual(0);
+                    expect(logger.messages.length).toEqual(1);
+                    expect(logger.messages[0]).toEqual(new Uint8Array(0));
+                });
 
-            unchunker.add(Uint8Array.of(MORE, 0, 0, 0, ID, 0, 0, 0, 0));
-            unchunker.add(Uint8Array.of(MORE, 0, 0, 0, ID, 0, 0, 0, 1, 1, 2));
-            unchunker.add(Uint8Array.of(END, 0, 0, 0, ID, 0, 0, 0, 2, 3));
+                it('unchunkifies multiple empty chunk messages', () => {
+                    const unchunker = new ReliableOrderedUnchunker(buffer);
+                    const logger = new LoggingUnchunker(unchunker);
 
-            expect(logger.messages.length).toEqual(1);
-            expect(logger.messages[0]).toEqual(Uint8Array.of(1, 2, 3));
-        });
+                    expect(logger.messages.length).toEqual(0);
 
-        it('unchunkifies multiple messages in parallel', () => {
-            const unchunker = new UnreliableUnorderedUnchunker();
-            const logger = new LoggingUnchunker(unchunker);
+                    unchunker.add(Uint8Array.of(MORE));
+                    unchunker.add(Uint8Array.of(MORE, 1, 2));
+                    unchunker.add(Uint8Array.of(END, 3));
 
-            expect(logger.messages.length).toEqual(0);
+                    expect(logger.messages.length).toEqual(1);
+                    expect(logger.messages[0]).toEqual(Uint8Array.of(1, 2, 3));
+                });
 
-            unchunker.add(Uint8Array.of(MORE, 0, 0, 0, ID, 0, 0, 0, 0, 1, 2));
-            unchunker.add(Uint8Array.of(MORE, 0, 0, 0, ID + 1, 0, 0, 0, 0, 3, 4));
-            unchunker.add(Uint8Array.of(END, 0, 0, 0, ID, 0, 0, 0, 1, 5, 6));
-            expect(logger.messages.length).toEqual(1);
-            unchunker.add(Uint8Array.of(END, 0, 0, 0, ID + 1, 0, 0, 0, 1, 7, 8));
-            expect(logger.messages.length).toEqual(2);
-            expect(logger.messages[0]).toEqual(Uint8Array.of(1, 2, 5, 6));
-            expect(logger.messages[1]).toEqual(Uint8Array.of(3, 4, 7, 8));
-        });
+                it('does not notify listeners for incomplete messages', () => {
+                    const unchunker = new ReliableOrderedUnchunker(buffer);
+                    const logger = new LoggingUnchunker(unchunker);
 
-        it('supports out of order messages', () => {
-            const unchunker = new UnreliableUnorderedUnchunker();
-            const logger = new LoggingUnchunker(unchunker);
+                    unchunker.add(Uint8Array.of(MORE, 7, 7, 7));
 
-            unchunker.add(Uint8Array.of(MORE, 0, 0, 0, ID, 0, 0, 0, 1, 3, 4));
-            unchunker.add(Uint8Array.of(MORE, 0, 0, 0, ID, 0, 0, 0, 0, 1, 2));
-            unchunker.add(Uint8Array.of(END, 0, 0, 0, ID, 0, 0, 0, 3, 7, 8));
+                    expect(logger.messages.length).toEqual(0);
+                });
 
-            expect(logger.messages.length).toEqual(0);
+                it('does not accept invalid chunks', () => {
+                    const unchunker = new ReliableOrderedUnchunker(buffer);
+                    const add = () => unchunker.add(new Uint8Array(0));
+                    expect(add).toThrowError('Invalid chunk: Too short');
+                });
 
-            unchunker.add(Uint8Array.of(MORE, 0, 0, 0, ID, 0, 0, 0, 2, 5, 6));
+                it('notifies listeners that have been added after receiving some msgs', () => {
+                    const unchunker = new ReliableOrderedUnchunker(buffer);
 
-            expect(logger.messages.length).toEqual(1);
-            expect(logger.messages[0]).toEqual(Uint8Array.of(1, 2, 3, 4, 5, 6, 7, 8));
-        });
+                    unchunker.add(Uint8Array.of(MORE, 1, 2));
+                    unchunker.add(Uint8Array.of(MORE, 3, 4));
 
-        it('does not notify listeners for incomplete messages', () => {
-            const unchunker = new UnreliableUnorderedUnchunker();
-            const logger = new LoggingUnchunker(unchunker);
+                    // Add listener only after two chunks have arrived
+                    const logger = new LoggingUnchunker(unchunker);
+                    unchunker.add(Uint8Array.of(END, 5, 6));
 
-            // End chunk with serial 1, no chunk with serial 0
-            unchunker.add(Uint8Array.of(END, 0, 0, 0, ID, 0, 0, 0, 1, 7, 7, 7));
+                    expect(logger.messages.length).toEqual(1);
+                    expect(logger.messages[0]).toEqual(Uint8Array.of(1, 2, 3, 4, 5, 6));
+                });
 
-            expect(logger.messages.length).toEqual(0);
-        });
+                it('does not accept invalid mode', () => {
+                    const unchunker = new ReliableOrderedUnchunker();
+                    const add = () => unchunker.add(Uint8Array.of(0));
+                    expect(add).toThrowError('Invalid chunk: Unexpected mode 0');
+                });
+            });
 
-        it('does not accept invalid chunks', () => {
-            const unchunker = new UnreliableUnorderedUnchunker();
-            const add = () => unchunker.add(Uint8Array.of(1, 2, 3));
-            expect(add).toThrowError('Invalid chunk: Too short');
-        });
+            describe(`integration (buffer=${hasBufferStr})`, () => {
+                it('passes 300 messages', () => {
+                    const unchunker = new ReliableOrderedUnchunker(buffer);
 
-        it('does not break if there\'s no listener registered', () => {
-            const unchunker = new UnreliableUnorderedUnchunker();
-            const add = () => unchunker.add(Uint8Array.of(END, 0, 0, 0, ID, 0, 0, 0, 0, 1, 2, 3));
-            expect(add).not.toThrowError();
-        });
+                    for (const _ of Array(100).keys()) {
+                        const logger = new LoggingUnchunker(unchunker);
 
-        it('notifies listeners that have been added after receiving some msgs', () => {
-            const unchunker = new UnreliableUnorderedUnchunker();
+                        expect(logger.messages.length).toEqual(0);
 
-            unchunker.add(Uint8Array.of(MORE, 0, 0, 0, ID, 0, 0, 0, 0, 1, 2));
-            unchunker.add(Uint8Array.of(MORE, 0, 0, 0, ID, 0, 0, 0, 1, 3, 4));
+                        const chunks = [
+                            // 1
+                            Uint8Array.of(MORE, 1, 2),
+                            Uint8Array.of(END, 3, 4),
+                            // 2
+                            Uint8Array.of(END, 5),
+                            // 3
+                            Uint8Array.of(MORE, 6, 7, 8),
+                            Uint8Array.of(MORE, 9, 10, 11),
+                            Uint8Array.of(MORE, 12, 13, 14),
+                            Uint8Array.of(END, 15),
+                        ];
 
-            // Add listener only after two chunks have arrived
-            const logger = new LoggingUnchunker(unchunker);
-            unchunker.add(Uint8Array.of(END, 0, 0, 0, ID, 0, 0, 0, 2, 5, 6));
-
-            expect(logger.messages.length).toEqual(1);
-            expect(logger.messages[0]).toEqual(Uint8Array.of(1, 2, 3, 4, 5, 6));
-        });
-
-        it('handles omitted messages', () => {
-            const unchunker = new UnreliableUnorderedUnchunker();
-            const logger = new LoggingUnchunker(unchunker);
-
-            unchunker.add(Uint8Array.of(MORE, 0, 0, 0, 3, 0, 0, 0, 1, 9, 10, 11));
-            unchunker.add(Uint8Array.of(MORE, 0, 0, 0, 1, 0, 0, 0, 0, 1, 2));
-            unchunker.add(Uint8Array.of(MORE, 0, 0, 0, 3, 0, 0, 0, 2, 12, 13, 14));
-            unchunker.add(Uint8Array.of(MORE, 0, 0, 0, 3, 0, 0, 0, 0, 6, 7, 8));
-            unchunker.add(Uint8Array.of(END, 0, 0, 0, 3, 0, 0, 0, 3, 15));
-
-            expect(logger.messages.length).toEqual(1);
-            expect(logger.messages).toContain(Uint8Array.of(6, 7, 8, 9, 10, 11, 12, 13, 14, 15));
-        });
-
+                        for (let chunk of chunks) {
+                            unchunker.add(chunk);
+                        }
+                        expect(logger.messages.length).toEqual(3);
+                        expect(logger.messages).toContain(Uint8Array.of(1, 2, 3, 4));
+                        expect(logger.messages).toContain(Uint8Array.of(5));
+                        expect(logger.messages).toContain(Uint8Array.of(6, 7, 8, 9, 10, 11, 12, 13, 14, 15));
+                    }
+                });
+            });
+        }
     });
 
-    describe('cleanup', () => {
-        it('supports garbage collection', async(done) => {
-            const unchunker = new UnreliableUnorderedUnchunker();
-            expect(unchunker.gc(1000)).toEqual(0);
-            unchunker.add(Uint8Array.of(MORE, 0, 0, 0, 1, 0, 0, 0, 0, 1, 2));
-            unchunker.add(Uint8Array.of(MORE, 0, 0, 0, 1, 0, 0, 0, 1, 3, 4));
-            unchunker.add(Uint8Array.of(MORE, 0, 0, 0, 2, 0, 0, 0, 0, 1, 2));
-            setTimeout(() => {
-                expect(unchunker.gc(1000)).toEqual(0);
-                expect(unchunker.gc(10)).toEqual(3);
-                expect(unchunker.gc(10)).toEqual(0);
-                done();
-            }, 20);
-        }, 1200);
+    describe('UnreliableUnorderedUnchunker', function() {
+        const MORE = 0;
+        const END = 1;
+        const ID = 42;
 
-    });
-
-    describe('integration', () => {
-        it('passes 100 shuffled integration tests', () => {
-            for (const _ of Array(100).keys()) {
+        describe('base', () => {
+            it('unchunkifies regular messages', () => {
                 const unchunker = new UnreliableUnorderedUnchunker();
                 const logger = new LoggingUnchunker(unchunker);
 
                 expect(logger.messages.length).toEqual(0);
 
-                // Chunks in random order
-                const chunks = [
-                    // 1
-                    Uint8Array.of(MORE, 0, 0, 0, 1, 0, 0, 0, 0, 1, 2),
-                    Uint8Array.of(END, 0, 0, 0, 1, 0, 0, 0, 1, 3, 4),
-                    // 2
-                    Uint8Array.of(END, 0, 0, 0, 2, 0, 0, 0, 0, 5),
-                    // 3
-                    Uint8Array.of(MORE, 0, 0, 0, 3, 0, 0, 0, 0, 6, 7, 8),
-                    Uint8Array.of(MORE, 0, 0, 0, 3, 0, 0, 0, 1, 9, 10, 11),
-                    Uint8Array.of(MORE, 0, 0, 0, 3, 0, 0, 0, 2, 12, 13, 14),
-                    Uint8Array.of(END, 0, 0, 0, 3, 0, 0, 0, 3, 15),
-                    // Incomplete
-                    Uint8Array.of(MORE, 0, 0, 0, 4, 0, 0, 0, 0, 23, 42)
-                ];
-                shuffle(chunks);
+                unchunker.add(Uint8Array.of(MORE, 0, 0, 0, ID, 0, 0, 0, 0, 1, 2, 3));
+                unchunker.add(Uint8Array.of(MORE, 0, 0, 0, ID, 0, 0, 0, 1, 4, 5, 6));
+                unchunker.add(Uint8Array.of(END, 0, 0, 0, ID, 0, 0, 0, 2, 7, 8));
 
-                for (let chunk of chunks) {
-                    unchunker.add(chunk);
-                }
-                expect(logger.messages.length).toEqual(3);
-                expect(logger.messages).toContain(Uint8Array.of(1, 2, 3, 4));
-                expect(logger.messages).toContain(Uint8Array.of(5));
+                expect(logger.messages.length).toEqual(1);
+                expect(logger.messages[0]).toEqual(Uint8Array.of(1, 2, 3, 4, 5, 6, 7, 8));
+            });
+
+            it('unchunkifies single-chunk messages', () => {
+                const unchunker = new UnreliableUnorderedUnchunker();
+                const logger = new LoggingUnchunker(unchunker);
+
+                expect(logger.messages.length).toEqual(0);
+
+                unchunker.add(Uint8Array.of(END, 0, 0, 0, ID, 0, 0, 0, 0, 7, 7, 7));
+
+                expect(logger.messages.length).toEqual(1);
+                expect(logger.messages[0]).toEqual(Uint8Array.of(7, 7, 7));
+            });
+
+            it('unchunkifies empty chunk messages', () => {
+                const unchunker = new UnreliableUnorderedUnchunker();
+                const logger = new LoggingUnchunker(unchunker);
+
+                expect(logger.messages.length).toEqual(0);
+
+                unchunker.add(Uint8Array.of(END, 0, 0, 0, ID, 0, 0, 0, 0));
+
+                expect(logger.messages.length).toEqual(1);
+                expect(logger.messages[0]).toEqual(new Uint8Array(0));
+            });
+
+            it('unchunkifies multiple empty chunk messages', () => {
+                const unchunker = new UnreliableUnorderedUnchunker();
+                const logger = new LoggingUnchunker(unchunker);
+
+                expect(logger.messages.length).toEqual(0);
+
+                unchunker.add(Uint8Array.of(MORE, 0, 0, 0, ID, 0, 0, 0, 0));
+                unchunker.add(Uint8Array.of(MORE, 0, 0, 0, ID, 0, 0, 0, 1, 1, 2));
+                unchunker.add(Uint8Array.of(END, 0, 0, 0, ID, 0, 0, 0, 2, 3));
+
+                expect(logger.messages.length).toEqual(1);
+                expect(logger.messages[0]).toEqual(Uint8Array.of(1, 2, 3));
+            });
+
+            it('unchunkifies multiple messages in parallel', () => {
+                const unchunker = new UnreliableUnorderedUnchunker();
+                const logger = new LoggingUnchunker(unchunker);
+
+                expect(logger.messages.length).toEqual(0);
+
+                unchunker.add(Uint8Array.of(MORE, 0, 0, 0, ID, 0, 0, 0, 0, 1, 2));
+                unchunker.add(Uint8Array.of(MORE, 0, 0, 0, ID + 1, 0, 0, 0, 0, 3, 4));
+                unchunker.add(Uint8Array.of(END, 0, 0, 0, ID, 0, 0, 0, 1, 5, 6));
+                expect(logger.messages.length).toEqual(1);
+                unchunker.add(Uint8Array.of(END, 0, 0, 0, ID + 1, 0, 0, 0, 1, 7, 8));
+                expect(logger.messages.length).toEqual(2);
+                expect(logger.messages[0]).toEqual(Uint8Array.of(1, 2, 5, 6));
+                expect(logger.messages[1]).toEqual(Uint8Array.of(3, 4, 7, 8));
+            });
+
+            it('supports out of order messages', () => {
+                const unchunker = new UnreliableUnorderedUnchunker();
+                const logger = new LoggingUnchunker(unchunker);
+
+                unchunker.add(Uint8Array.of(MORE, 0, 0, 0, ID, 0, 0, 0, 1, 3, 4));
+                unchunker.add(Uint8Array.of(MORE, 0, 0, 0, ID, 0, 0, 0, 0, 1, 2));
+                unchunker.add(Uint8Array.of(END, 0, 0, 0, ID, 0, 0, 0, 3, 7, 8));
+
+                expect(logger.messages.length).toEqual(0);
+
+                unchunker.add(Uint8Array.of(MORE, 0, 0, 0, ID, 0, 0, 0, 2, 5, 6));
+
+                expect(logger.messages.length).toEqual(1);
+                expect(logger.messages[0]).toEqual(Uint8Array.of(1, 2, 3, 4, 5, 6, 7, 8));
+            });
+
+            it('does not notify listeners for incomplete messages', () => {
+                const unchunker = new UnreliableUnorderedUnchunker();
+                const logger = new LoggingUnchunker(unchunker);
+
+                // End chunk with serial 1, no chunk with serial 0
+                unchunker.add(Uint8Array.of(END, 0, 0, 0, ID, 0, 0, 0, 1, 7, 7, 7));
+
+                expect(logger.messages.length).toEqual(0);
+            });
+
+            it('does not accept invalid chunks', () => {
+                const unchunker = new UnreliableUnorderedUnchunker();
+                const add = () => unchunker.add(Uint8Array.of(1, 2, 3));
+                expect(add).toThrowError('Invalid chunk: Too short');
+            });
+
+            it('notifies listeners that have been added after receiving some msgs', () => {
+                const unchunker = new UnreliableUnorderedUnchunker();
+
+                unchunker.add(Uint8Array.of(MORE, 0, 0, 0, ID, 0, 0, 0, 0, 1, 2));
+                unchunker.add(Uint8Array.of(MORE, 0, 0, 0, ID, 0, 0, 0, 1, 3, 4));
+
+                // Add listener only after two chunks have arrived
+                const logger = new LoggingUnchunker(unchunker);
+                unchunker.add(Uint8Array.of(END, 0, 0, 0, ID, 0, 0, 0, 2, 5, 6));
+
+                expect(logger.messages.length).toEqual(1);
+                expect(logger.messages[0]).toEqual(Uint8Array.of(1, 2, 3, 4, 5, 6));
+            });
+
+            it('handles omitted messages', () => {
+                const unchunker = new UnreliableUnorderedUnchunker();
+                const logger = new LoggingUnchunker(unchunker);
+
+                unchunker.add(Uint8Array.of(MORE, 0, 0, 0, 3, 0, 0, 0, 1, 9, 10, 11));
+                unchunker.add(Uint8Array.of(MORE, 0, 0, 0, 1, 0, 0, 0, 0, 1, 2));
+                unchunker.add(Uint8Array.of(MORE, 0, 0, 0, 3, 0, 0, 0, 2, 12, 13, 14));
+                unchunker.add(Uint8Array.of(MORE, 0, 0, 0, 3, 0, 0, 0, 0, 6, 7, 8));
+                unchunker.add(Uint8Array.of(END, 0, 0, 0, 3, 0, 0, 0, 3, 15));
+
+                expect(logger.messages.length).toEqual(1);
                 expect(logger.messages).toContain(Uint8Array.of(6, 7, 8, 9, 10, 11, 12, 13, 14, 15));
-            }
+            });
+
+            it('does not accept invalid mode', () => {
+                const unchunker = new UnreliableUnorderedUnchunker();
+                const add = () => unchunker.add(Uint8Array.of(6, 0, 0, 0, 0, 1, 1, 1, 1));
+                expect(add).toThrowError('Invalid chunk: Unexpected mode 6');
+            });
+        });
+
+        describe('cleanup', () => {
+            it('supports garbage collection', async(done) => {
+                const unchunker = new UnreliableUnorderedUnchunker();
+                expect(unchunker.gc(1000)).toEqual(0);
+                unchunker.add(Uint8Array.of(MORE, 0, 0, 0, 1, 0, 0, 0, 0, 1, 2));
+                unchunker.add(Uint8Array.of(MORE, 0, 0, 0, 1, 0, 0, 0, 1, 3, 4));
+                unchunker.add(Uint8Array.of(MORE, 0, 0, 0, 2, 0, 0, 0, 0, 1, 2));
+                setTimeout(() => {
+                    expect(unchunker.gc(1000)).toEqual(0);
+                    expect(unchunker.gc(10)).toEqual(3);
+                    expect(unchunker.gc(10)).toEqual(0);
+                    done();
+                }, 20);
+            }, 1200);
+
+        });
+
+        describe('integration', () => {
+            it('passes 100 shuffled integration tests', () => {
+                for (const _ of Array(100).keys()) {
+                    const unchunker = new UnreliableUnorderedUnchunker();
+                    const logger = new LoggingUnchunker(unchunker);
+
+                    expect(logger.messages.length).toEqual(0);
+
+                    // Chunks in random order
+                    const chunks = [
+                        // 1
+                        Uint8Array.of(MORE, 0, 0, 0, 1, 0, 0, 0, 0, 1, 2),
+                        Uint8Array.of(END, 0, 0, 0, 1, 0, 0, 0, 1, 3, 4),
+                        // 2
+                        Uint8Array.of(END, 0, 0, 0, 2, 0, 0, 0, 0, 5),
+                        // 3
+                        Uint8Array.of(MORE, 0, 0, 0, 3, 0, 0, 0, 0, 6, 7, 8),
+                        Uint8Array.of(MORE, 0, 0, 0, 3, 0, 0, 0, 1, 9, 10, 11),
+                        Uint8Array.of(MORE, 0, 0, 0, 3, 0, 0, 0, 2, 12, 13, 14),
+                        Uint8Array.of(END, 0, 0, 0, 3, 0, 0, 0, 3, 15),
+                        // Incomplete
+                        Uint8Array.of(MORE, 0, 0, 0, 4, 0, 0, 0, 0, 23, 42)
+                    ];
+                    shuffle(chunks);
+
+                    for (let chunk of chunks) {
+                        unchunker.add(chunk);
+                    }
+                    expect(logger.messages.length).toEqual(3);
+                    expect(logger.messages).toContain(Uint8Array.of(1, 2, 3, 4));
+                    expect(logger.messages).toContain(Uint8Array.of(5));
+                    expect(logger.messages).toContain(Uint8Array.of(6, 7, 8, 9, 10, 11, 12, 13, 14, 15));
+                }
+            });
         });
     });
-})};
+};

--- a/tests/test_unchunker.spec.ts
+++ b/tests/test_unchunker.spec.ts
@@ -1,14 +1,14 @@
 /// <reference path="jasmine.d.ts" />
 /// <reference path="../chunked-dc.d.ts" />
 
-import {Unchunker} from "../src/main";
+import {UnreliableUnorderedUnchunker} from '../src/main';
 
 /**
- * A wrapper around the unchunker that stores finished messages in a list.
+ * A wrapper around an unchunker that stores finished messages in a list.
  */
 class LoggingUnchunker {
     public messages: Uint8Array[] = [];
-    constructor(unchunker: Unchunker) {
+    constructor(unchunker: chunkedDc.Unchunker) {
         unchunker.onMessage = (message: Uint8Array) => {
             this.messages.push(message);
         }
@@ -20,7 +20,7 @@ class LoggingUnchunker {
  * http://stackoverflow.com/a/2450976/284318
  */
 function shuffle(array) {
-    var currentIndex = array.length, temporaryValue, randomIndex;
+    let currentIndex = array.length, temporaryValue, randomIndex;
 
     // While there remain elements to shuffle...
     while (0 !== currentIndex) {
@@ -38,163 +38,155 @@ function shuffle(array) {
     return array;
 }
 
-export default () => { describe('Unchunker', function() {
-
+export default () => { describe('UnreliableUnorderedUnchunker', function() {
     const MORE = 0;
     const END = 1;
     const ID = 42;
 
     describe('base', () => {
-
         it('unchunkifies regular messages', () => {
-            const unchunker = new Unchunker();
+            const unchunker = new UnreliableUnorderedUnchunker();
             const logger = new LoggingUnchunker(unchunker);
 
             expect(logger.messages.length).toEqual(0);
 
-            unchunker.add(Uint8Array.of(MORE, 0, 0, 0, ID, 0, 0, 0, 0, 1, 2, 3).buffer);
-            unchunker.add(Uint8Array.of(MORE, 0, 0, 0, ID, 0, 0, 0, 1, 4, 5, 6).buffer);
-            unchunker.add(Uint8Array.of(END, 0, 0, 0, ID, 0, 0, 0, 2, 7, 8).buffer);
+            unchunker.add(Uint8Array.of(MORE, 0, 0, 0, ID, 0, 0, 0, 0, 1, 2, 3));
+            unchunker.add(Uint8Array.of(MORE, 0, 0, 0, ID, 0, 0, 0, 1, 4, 5, 6));
+            unchunker.add(Uint8Array.of(END, 0, 0, 0, ID, 0, 0, 0, 2, 7, 8));
 
             expect(logger.messages.length).toEqual(1);
             expect(logger.messages[0]).toEqual(Uint8Array.of(1, 2, 3, 4, 5, 6, 7, 8));
         });
 
         it('unchunkifies single-chunk messages', () => {
-            const unchunker = new Unchunker();
+            const unchunker = new UnreliableUnorderedUnchunker();
             const logger = new LoggingUnchunker(unchunker);
 
             expect(logger.messages.length).toEqual(0);
 
-            unchunker.add(Uint8Array.of(END, 0, 0, 0, ID, 0, 0, 0, 0, 7, 7, 7).buffer);
+            unchunker.add(Uint8Array.of(END, 0, 0, 0, ID, 0, 0, 0, 0, 7, 7, 7));
 
             expect(logger.messages.length).toEqual(1);
             expect(logger.messages[0]).toEqual(Uint8Array.of(7, 7, 7));
         });
 
-        it('unchunkifies empty single-chunk messages', () => {
-            const unchunker = new Unchunker();
+        it('unchunkifies empty chunk messages', () => {
+            const unchunker = new UnreliableUnorderedUnchunker();
             const logger = new LoggingUnchunker(unchunker);
 
             expect(logger.messages.length).toEqual(0);
 
-            unchunker.add(Uint8Array.of(END, 0, 0, 0, ID, 0, 0, 0, 0).buffer);
+            unchunker.add(Uint8Array.of(END, 0, 0, 0, ID, 0, 0, 0, 0));
 
             expect(logger.messages.length).toEqual(1);
             expect(logger.messages[0]).toEqual(new Uint8Array(0));
         });
 
-        it('unchunkifies multiple messages in parallel', () => {
-            const unchunker = new Unchunker();
+        it('unchunkifies multiple empty chunk messages', () => {
+            const unchunker = new UnreliableUnorderedUnchunker();
             const logger = new LoggingUnchunker(unchunker);
 
             expect(logger.messages.length).toEqual(0);
 
-            unchunker.add(Uint8Array.of(MORE, 0, 0, 0, ID, 0, 0, 0, 0, 1, 2).buffer);
-            unchunker.add(Uint8Array.of(MORE, 0, 0, 0, ID + 1, 0, 0, 0, 0, 3, 4).buffer);
-            unchunker.add(Uint8Array.of(END, 0, 0, 0, ID, 0, 0, 0, 1, 5, 6).buffer);
+            unchunker.add(Uint8Array.of(MORE, 0, 0, 0, ID, 0, 0, 0, 0));
+            unchunker.add(Uint8Array.of(MORE, 0, 0, 0, ID, 0, 0, 0, 1, 1, 2));
+            unchunker.add(Uint8Array.of(END, 0, 0, 0, ID, 0, 0, 0, 2, 3));
+
             expect(logger.messages.length).toEqual(1);
-            unchunker.add(Uint8Array.of(END, 0, 0, 0, ID + 1, 0, 0, 0, 1, 7, 8).buffer);
+            expect(logger.messages[0]).toEqual(Uint8Array.of(1, 2, 3));
+        });
+
+        it('unchunkifies multiple messages in parallel', () => {
+            const unchunker = new UnreliableUnorderedUnchunker();
+            const logger = new LoggingUnchunker(unchunker);
+
+            expect(logger.messages.length).toEqual(0);
+
+            unchunker.add(Uint8Array.of(MORE, 0, 0, 0, ID, 0, 0, 0, 0, 1, 2));
+            unchunker.add(Uint8Array.of(MORE, 0, 0, 0, ID + 1, 0, 0, 0, 0, 3, 4));
+            unchunker.add(Uint8Array.of(END, 0, 0, 0, ID, 0, 0, 0, 1, 5, 6));
+            expect(logger.messages.length).toEqual(1);
+            unchunker.add(Uint8Array.of(END, 0, 0, 0, ID + 1, 0, 0, 0, 1, 7, 8));
             expect(logger.messages.length).toEqual(2);
             expect(logger.messages[0]).toEqual(Uint8Array.of(1, 2, 5, 6));
             expect(logger.messages[1]).toEqual(Uint8Array.of(3, 4, 7, 8));
         });
 
         it('supports out of order messages', () => {
-            const unchunker = new Unchunker();
+            const unchunker = new UnreliableUnorderedUnchunker();
             const logger = new LoggingUnchunker(unchunker);
 
-            unchunker.add(Uint8Array.of(MORE, 0, 0, 0, ID, 0, 0, 0, 1, 3, 4).buffer);
-            unchunker.add(Uint8Array.of(MORE, 0, 0, 0, ID, 0, 0, 0, 0, 1, 2).buffer);
-            unchunker.add(Uint8Array.of(END, 0, 0, 0, ID, 0, 0, 0, 3, 7, 8).buffer);
+            unchunker.add(Uint8Array.of(MORE, 0, 0, 0, ID, 0, 0, 0, 1, 3, 4));
+            unchunker.add(Uint8Array.of(MORE, 0, 0, 0, ID, 0, 0, 0, 0, 1, 2));
+            unchunker.add(Uint8Array.of(END, 0, 0, 0, ID, 0, 0, 0, 3, 7, 8));
 
             expect(logger.messages.length).toEqual(0);
 
-            unchunker.add(Uint8Array.of(MORE, 0, 0, 0, ID, 0, 0, 0, 2, 5, 6).buffer);
+            unchunker.add(Uint8Array.of(MORE, 0, 0, 0, ID, 0, 0, 0, 2, 5, 6));
 
             expect(logger.messages.length).toEqual(1);
             expect(logger.messages[0]).toEqual(Uint8Array.of(1, 2, 3, 4, 5, 6, 7, 8));
         });
 
         it('does not notify listeners for incomplete messages', () => {
-            const unchunker = new Unchunker();
+            const unchunker = new UnreliableUnorderedUnchunker();
             const logger = new LoggingUnchunker(unchunker);
 
             // End chunk with serial 1, no chunk with serial 0
-            unchunker.add(Uint8Array.of(END, 0, 0, 0, ID, 0, 0, 0, 1, 7, 7, 7).buffer);
+            unchunker.add(Uint8Array.of(END, 0, 0, 0, ID, 0, 0, 0, 1, 7, 7, 7));
 
             expect(logger.messages.length).toEqual(0);
         });
 
         it('does not accept invalid chunks', () => {
-            const unchunker = new Unchunker();
-            const add = () => unchunker.add(Uint8Array.of(1, 2, 3).buffer);
+            const unchunker = new UnreliableUnorderedUnchunker();
+            const add = () => unchunker.add(Uint8Array.of(1, 2, 3));
             expect(add).toThrowError('Invalid chunk: Too short');
         });
 
-        it('does not accept empty first chunks', () => {
-            const unchunker = new Unchunker();
-
-            unchunker.add(Uint8Array.of(MORE, 0, 0, 0, ID, 0, 0, 0, 0).buffer);
-            unchunker.add(Uint8Array.of(MORE, 0, 0, 0, ID, 0, 0, 0, 1, 1, 2).buffer);
-            const finalize = () => unchunker.add(Uint8Array.of(END, 0, 0, 0, ID, 0, 0, 0, 2, 3).buffer);
-            expect(finalize).toThrowError('No chunk may be larger than the first chunk of that message.');
-        });
-
-        it('ignores repeated chunks with the same serial', () => {
-            const unchunker = new Unchunker();
-            const logger = new LoggingUnchunker(unchunker);
-
-            unchunker.add(Uint8Array.of(MORE, 0, 0, 0, ID, 0, 0, 0, 0, 1, 2).buffer);
-            unchunker.add(Uint8Array.of(MORE, 0, 0, 0, ID, 0, 0, 0, 0, 3, 4).buffer);
-            unchunker.add(Uint8Array.of(END, 0, 0, 0, ID, 0, 0, 0, 1, 5, 6).buffer);
-
-            expect(logger.messages.length).toEqual(1);
-            expect(logger.messages[0]).toEqual(Uint8Array.of(1, 2, 5, 6));
-        });
-
-        it('ignores end chunks with the same serial', () => {
-            const unchunker = new Unchunker();
-            const logger = new LoggingUnchunker(unchunker);
-
-            unchunker.add(Uint8Array.of(MORE, 0, 0, 0, ID, 0, 0, 0, 0, 1, 2).buffer);
-            unchunker.add(Uint8Array.of(END, 0, 0, 0, ID, 0, 0, 0, 0, 3, 4).buffer);
-            unchunker.add(Uint8Array.of(END, 0, 0, 0, ID, 0, 0, 0, 1, 5, 6).buffer);
-
-            expect(logger.messages.length).toEqual(1);
-            expect(logger.messages[0]).toEqual(Uint8Array.of(1, 2, 5, 6));
-        });
-
         it('does not break if there\'s no listener registered', () => {
-            const unchunker = new Unchunker();
-            const add = () => unchunker.add(Uint8Array.of(END, 0, 0, 0, ID, 0, 0, 0, 0, 1, 2, 3).buffer);
+            const unchunker = new UnreliableUnorderedUnchunker();
+            const add = () => unchunker.add(Uint8Array.of(END, 0, 0, 0, ID, 0, 0, 0, 0, 1, 2, 3));
             expect(add).not.toThrowError();
         });
 
         it('notifies listeners that have been added after receiving some msgs', () => {
-            const unchunker = new Unchunker();
+            const unchunker = new UnreliableUnorderedUnchunker();
 
-            unchunker.add(Uint8Array.of(MORE, 0, 0, 0, ID, 0, 0, 0, 0, 1, 2).buffer);
-            unchunker.add(Uint8Array.of(MORE, 0, 0, 0, ID, 0, 0, 0, 1, 3, 4).buffer);
+            unchunker.add(Uint8Array.of(MORE, 0, 0, 0, ID, 0, 0, 0, 0, 1, 2));
+            unchunker.add(Uint8Array.of(MORE, 0, 0, 0, ID, 0, 0, 0, 1, 3, 4));
 
             // Add listener only after two chunks have arrived
             const logger = new LoggingUnchunker(unchunker);
-            unchunker.add(Uint8Array.of(END, 0, 0, 0, ID, 0, 0, 0, 2, 5, 6).buffer);
+            unchunker.add(Uint8Array.of(END, 0, 0, 0, ID, 0, 0, 0, 2, 5, 6));
 
             expect(logger.messages.length).toEqual(1);
             expect(logger.messages[0]).toEqual(Uint8Array.of(1, 2, 3, 4, 5, 6));
         });
 
+        it('handles omitted messages', () => {
+            const unchunker = new UnreliableUnorderedUnchunker();
+            const logger = new LoggingUnchunker(unchunker);
+
+            unchunker.add(Uint8Array.of(MORE, 0, 0, 0, 3, 0, 0, 0, 1, 9, 10, 11));
+            unchunker.add(Uint8Array.of(MORE, 0, 0, 0, 1, 0, 0, 0, 0, 1, 2));
+            unchunker.add(Uint8Array.of(MORE, 0, 0, 0, 3, 0, 0, 0, 2, 12, 13, 14));
+            unchunker.add(Uint8Array.of(MORE, 0, 0, 0, 3, 0, 0, 0, 0, 6, 7, 8));
+            unchunker.add(Uint8Array.of(END, 0, 0, 0, 3, 0, 0, 0, 3, 15));
+
+            expect(logger.messages.length).toEqual(1);
+            expect(logger.messages).toContain(Uint8Array.of(6, 7, 8, 9, 10, 11, 12, 13, 14, 15));
+        });
+
     });
 
     describe('cleanup', () => {
-
         it('supports garbage collection', async(done) => {
-            const unchunker = new Unchunker();
+            const unchunker = new UnreliableUnorderedUnchunker();
             expect(unchunker.gc(1000)).toEqual(0);
-            unchunker.add(Uint8Array.of(MORE, 0, 0, 0, 1, 0, 0, 0, 0, 1, 2).buffer);
-            unchunker.add(Uint8Array.of(MORE, 0, 0, 0, 1, 0, 0, 0, 1, 3, 4).buffer);
-            unchunker.add(Uint8Array.of(MORE, 0, 0, 0, 2, 0, 0, 0, 0, 1, 2).buffer);
+            unchunker.add(Uint8Array.of(MORE, 0, 0, 0, 1, 0, 0, 0, 0, 1, 2));
+            unchunker.add(Uint8Array.of(MORE, 0, 0, 0, 1, 0, 0, 0, 1, 3, 4));
+            unchunker.add(Uint8Array.of(MORE, 0, 0, 0, 2, 0, 0, 0, 0, 1, 2));
             setTimeout(() => {
                 expect(unchunker.gc(1000)).toEqual(0);
                 expect(unchunker.gc(10)).toEqual(3);
@@ -205,86 +197,39 @@ export default () => { describe('Unchunker', function() {
 
     });
 
-    describe('context', () => {
-
-        it('passes an empty context list to the handler by default', async(done) => {
-            const unchunker = new Unchunker();
-            unchunker.onMessage = (message: Uint8Array, context: any[]) => {
-                expect(context).toEqual([]);
-                done();
-            };
-            unchunker.add(Uint8Array.of(MORE, 0, 0, 0, ID, 0, 0, 0, 0, 1, 2).buffer);
-            unchunker.add(Uint8Array.of(END, 0, 0, 0, ID, 0, 0, 0, 2, 5, 6).buffer);
-            unchunker.add(Uint8Array.of(MORE, 0, 0, 0, ID, 0, 0, 0, 1, 3, 4).buffer);
-        });
-
-        it('passes sorted context objects to the handler', async(done) => {
-            const unchunker = new Unchunker();
-            unchunker.onMessage = (message: Uint8Array, context: any[]) => {
-                expect(context).toEqual([1, 2, 3]);
-                done();
-            };
-            unchunker.add(Uint8Array.of(MORE, 0, 0, 0, ID, 0, 0, 0, 0, 1, 2).buffer, 1);
-            unchunker.add(Uint8Array.of(END, 0, 0, 0, ID, 0, 0, 0, 2, 5, 6).buffer, 3);
-            unchunker.add(Uint8Array.of(MORE, 0, 0, 0, ID, 0, 0, 0, 1, 3, 4).buffer, 2);
-        });
-
-        it('passes single-chunk context objects to the handler', async(done) => {
-            const unchunker = new Unchunker();
-            unchunker.onMessage = (message: Uint8Array, context: any[]) => {
-                expect(context).toEqual([42]);
-                done();
-            };
-            unchunker.add(Uint8Array.of(END, 0, 0, 0, ID, 0, 0, 0, 0, 1, 2, 3).buffer, 42);
-        });
-
-        it('only passes defined context objects to the handler', async(done) => {
-            const unchunker = new Unchunker();
-            unchunker.onMessage = (message: Uint8Array, context: any[]) => {
-                expect(context).toEqual([1, 3]);
-                done();
-            };
-            unchunker.add(Uint8Array.of(END, 0, 0, 0, ID, 0, 0, 0, 2, 5, 6).buffer, 3);
-            unchunker.add(Uint8Array.of(MORE, 0, 0, 0, ID, 0, 0, 0, 0, 1, 2).buffer, 1);
-            unchunker.add(Uint8Array.of(MORE, 0, 0, 0, ID, 0, 0, 0, 1, 3, 4).buffer);
-        });
-
-    });
-
     describe('integration', () => {
+        it('passes 100 shuffled integration tests', () => {
+            for (const _ of Array(100).keys()) {
+                const unchunker = new UnreliableUnorderedUnchunker();
+                const logger = new LoggingUnchunker(unchunker);
 
-        it('passes an integration test', () => {
-            const unchunker = new Unchunker();
-            const logger = new LoggingUnchunker(unchunker);
+                expect(logger.messages.length).toEqual(0);
 
-            expect(logger.messages.length).toEqual(0);
+                // Chunks in random order
+                const chunks = [
+                    // 1
+                    Uint8Array.of(MORE, 0, 0, 0, 1, 0, 0, 0, 0, 1, 2),
+                    Uint8Array.of(END, 0, 0, 0, 1, 0, 0, 0, 1, 3, 4),
+                    // 2
+                    Uint8Array.of(END, 0, 0, 0, 2, 0, 0, 0, 0, 5),
+                    // 3
+                    Uint8Array.of(MORE, 0, 0, 0, 3, 0, 0, 0, 0, 6, 7, 8),
+                    Uint8Array.of(MORE, 0, 0, 0, 3, 0, 0, 0, 1, 9, 10, 11),
+                    Uint8Array.of(MORE, 0, 0, 0, 3, 0, 0, 0, 2, 12, 13, 14),
+                    Uint8Array.of(END, 0, 0, 0, 3, 0, 0, 0, 3, 15),
+                    // Incomplete
+                    Uint8Array.of(MORE, 0, 0, 0, 4, 0, 0, 0, 0, 23, 42)
+                ];
+                shuffle(chunks);
 
-            // Chunks in random order
-            const chunks = [
-                // 1
-                Uint8Array.of(MORE, 0, 0, 0, 1, 0, 0, 0, 0, 1, 2),
-                Uint8Array.of(END, 0, 0, 0, 1, 0, 0, 0, 1, 3, 4),
-                // 2
-                Uint8Array.of(END, 0, 0, 0, 2, 0, 0, 0, 0, 5),
-                // 3
-                Uint8Array.of(MORE, 0, 0, 0, 3, 0, 0, 0, 0, 6, 7, 8),
-                Uint8Array.of(MORE, 0, 0, 0, 3, 0, 0, 0, 1, 9, 10, 11),
-                Uint8Array.of(MORE, 0, 0, 0, 3, 0, 0, 0, 2, 12, 13, 14),
-                Uint8Array.of(END, 0, 0, 0, 3, 0, 0, 0, 3, 15),
-                // Incomplete
-                Uint8Array.of(MORE, 0, 0, 0, 4, 0, 0, 0, 0, 23, 42)
-            ];
-            shuffle(chunks);
-
-            for (let chunk of chunks) {
-                unchunker.add(chunk.buffer);
+                for (let chunk of chunks) {
+                    unchunker.add(chunk);
+                }
+                expect(logger.messages.length).toEqual(3);
+                expect(logger.messages).toContain(Uint8Array.of(1, 2, 3, 4));
+                expect(logger.messages).toContain(Uint8Array.of(5));
+                expect(logger.messages).toContain(Uint8Array.of(6, 7, 8, 9, 10, 11, 12, 13, 14, 15));
             }
-            expect(logger.messages.length).toEqual(3);
-            expect(logger.messages).toContain(Uint8Array.of(1, 2, 3, 4));
-            expect(logger.messages).toContain(Uint8Array.of(5));
-            expect(logger.messages).toContain(Uint8Array.of(6, 7, 8, 9, 10, 11, 12, 13, 14, 15));
         });
-
     });
-
 })};

--- a/tests/test_unchunker.spec.ts
+++ b/tests/test_unchunker.spec.ts
@@ -135,6 +135,12 @@ export default () => {
                     const add = () => unchunker.add(Uint8Array.of(0));
                     expect(add).toThrowError('Invalid chunk: Unexpected mode 0');
                 });
+
+                it('does not accept reserved mode', () => {
+                    const unchunker = new ReliableOrderedUnchunker();
+                    const add = () => unchunker.add(Uint8Array.of(2));
+                    expect(add).toThrowError('Invalid chunk: Unexpected mode 2');
+                });
             });
 
             describe(`integration (buffer=${hasBufferStr})`, () => {
@@ -310,6 +316,12 @@ export default () => {
                 const unchunker = new UnreliableUnorderedUnchunker();
                 const add = () => unchunker.add(Uint8Array.of(6, 0, 0, 0, 0, 1, 1, 1, 1));
                 expect(add).toThrowError('Invalid chunk: Unexpected mode 6');
+            });
+
+            it('does not accept reserved mode', () => {
+                const unchunker = new ReliableOrderedUnchunker();
+                const add = () => unchunker.add(Uint8Array.of(2));
+                expect(add).toThrowError('Invalid chunk: Unexpected mode 2');
             });
         });
 

--- a/tests/tests.ts
+++ b/tests/tests.ts
@@ -1,9 +1,9 @@
 import '../node_modules/@babel/polyfill/dist/polyfill'; // Include ES5 polyfills
 
-import test_chunker from "./test_chunker.spec";
-import test_chunk from "./test_chunk.spec";
-import test_common from "./test_common.spec";
-import test_unchunker from "./test_unchunker.spec";
+import test_chunker from './test_chunker.spec';
+import test_chunk from './test_chunk.spec';
+import test_common from './test_common.spec';
+import test_unchunker from './test_unchunker.spec';
 
 var counter = 1;
 beforeEach(() => console.info('------ TEST', counter++, 'BEGIN ------'));

--- a/tslint.json
+++ b/tslint.json
@@ -1,7 +1,7 @@
 {
     "extends": "tslint:recommended",
     "rules": {
-        "file-header": [true, "Copyright \\(C\\) 2016-2018"],
+        "file-header": [true, "Copyright \\(C\\) 2016-2019"],
         "indent": [true, "spaces"],
         "interface-name": [true, "never-prefix"],
         "max-classes-per-file": false,


### PR DESCRIPTION
Adds support for two modes: reliable/ordered and unreliable/unordered. The wire format is backwards compatible for chunks being received. However, the sender must use the unreliable/unordered mode for sending chunks in case it wants to ensure backwards compatibility.

The code has been mostly rewritten and optimised for performance as well as reduced copying. If desired, the Chunker subclasses can reuse a buffer when handing out chunks to reduce allocations which results in significant performance improvements. Furthermore, the Unchunker classes do not (always) copy chunks which means the caller should consider the chunk's buffer as transferred.

Further changes:

- Remove the ability to store a context when adding a chunk to an Unchunker instance.
- Chunker and Unchunker classes now only accept Uint8Array instances for chunks and messages.

To do:

  - [x] Resolve performance issues of unchunker
  - [x] Fix out-of-order reassembling (regression)
  - [x] Add missing tests
  - [x] Update readme

Resolves #28.