### PR TITLE
Add export notation for typescript module

### DIFF
--- a/chunked-dc.d.ts
+++ b/chunked-dc.d.ts
@@ -65,3 +65,4 @@ declare namespace chunkedDc {
 
 // Entry point
 declare var chunkedDc: chunkedDc.Standalone;
+export = chunkedDc;


### PR DESCRIPTION
Upon trying to use this library in a typescript project with `esnext` as the module type my IDE (IntelliJ Ultiimate) found the following typescript error:
```
TS2306: File 'C:/.../node_modules/@saltyrtc/chunked-dc/chunked-dc.d.ts' is not a module.
```

The above error appeared when attempting to import the library via:
```typescript
import chunkedDc from "@saltyrtc/chunked-dc";
```
Or
```typescript
import {ReliableOrderedChunker, ReliableOrderedUnchunker} from "@saltyrtc/chunked-dc";
```
After looking around for a solution, the eventual fix was to include this export line suggested by this [SO answer](https://stackoverflow.com/a/32805764) with the [typescript documentation](https://www.typescriptlang.org/docs/handbook/modules.html#export--and-import--require) on how it exports a single object to be compatible with CommonJS and AMD.